### PR TITLE
Feat/add findex redis v7

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -64,7 +64,7 @@ jobs:
       archive-name: ${{ matrix.archive-name }}
       target: ${{ matrix.target }}
       debug_or_release: ${{ inputs.debug_or_release }}
-      skip_services_tests: --skip test_findex --skip test_all_authentications --skip test_server_auth_matrix --skip test_datasets
+      skip_services_tests: --skip test_findex --skip test_all_authentications --skip test_server_auth_matrix --skip test_datasets --skip test_permissions
 
   windows-2022:
     if: inputs.debug_or_release == 'release'

--- a/crate/server/src/config/params/db_params.rs
+++ b/crate/server/src/config/params/db_params.rs
@@ -16,7 +16,7 @@ impl DbParams {
     }
 }
 impl Default for DbParams {
-    #[allow(clippy::expect_used)]
+    #[allow(clippy::expect_used)] // Won't panic because the URL is valid
     fn default() -> Self {
         Self::Redis(Url::parse("redis://localhost:6379").expect("Invalid default URL"))
     }
@@ -44,7 +44,6 @@ fn redact_url(original: &Url) -> Url {
         url.set_password(Some("****"))
             .expect("masking password failed");
     }
-
     url
 }
 

--- a/crate/server/src/database/database_traits.rs
+++ b/crate/server/src/database/database_traits.rs
@@ -48,7 +48,7 @@ pub(crate) trait FindexMemoryTrait:
     //
 }
 
-#[allow(dead_code)] // code is actually used
+#[allow(dead_code)] // false positive, used in crate/server/src/database/redis/mod.rs
 #[async_trait]
 pub(crate) trait DatabaseTraits:
     PermissionsTrait + DatasetsTrait + FindexMemoryTrait

--- a/crate/server/src/error/server.rs
+++ b/crate/server/src/error/server.rs
@@ -117,7 +117,7 @@ macro_rules! findex_server_bail {
     };
 }
 
-#[allow(clippy::expect_used)]
+#[allow(clippy::expect_used)] // ok in tests
 #[cfg(test)]
 mod tests {
     use super::FindexServerError;

--- a/crate/server/src/lib.rs
+++ b/crate/server/src/lib.rs
@@ -60,6 +60,6 @@ pub mod findex_server;
 pub mod middlewares;
 pub mod routes;
 
-#[allow(clippy::panic, clippy::unwrap_used, clippy::expect_used, unsafe_code)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests;

--- a/crate/server/src/main.rs
+++ b/crate/server/src/main.rs
@@ -18,7 +18,6 @@ const FINDEX_SERVER_CONF: &str = "/etc/cosmian/findex_server.toml";
 /// This function sets up the necessary environment variables and logging
 /// options, then parses the command line arguments using [`ClapConfig::parse()`](https://docs.rs/clap/latest/clap/struct.ClapConfig.html#method.parse).
 #[tokio::main]
-#[allow(clippy::needless_return)]
 async fn main() -> FResult<()> {
     // Set up environment variables and logging options
     if std::env::var("RUST_BACKTRACE").is_err() {

--- a/crate/server/src/middlewares/main.rs
+++ b/crate/server/src/middlewares/main.rs
@@ -62,7 +62,6 @@ where
     S::Future: 'static,
 {
     type Error = Error;
-    #[allow(clippy::type_complexity)]
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
     type Response = ServiceResponse<EitherBody<B, BoxBody>>;
 

--- a/crate/server/src/middlewares/ssl_auth.rs
+++ b/crate/server/src/middlewares/ssl_auth.rs
@@ -95,7 +95,6 @@ where
     S::Future: 'static,
 {
     type Error = Error;
-    #[allow(clippy::type_complexity)]
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
     type Response = ServiceResponse<EitherBody<B, BoxBody>>;
 

--- a/crate/server/src/routes/findex.rs
+++ b/crate/server/src/routes/findex.rs
@@ -20,7 +20,7 @@ use crate::{
     routes::{check_permission, error::ResponseBytes},
 };
 
-// todo(hatem): reduce cloning
+// TODO(hatem): reduce cloning
 
 #[allow(clippy::indexing_slicing)]
 fn prepend_index_id(
@@ -78,6 +78,7 @@ pub(crate) async fn findex_guarded_write(
     findex_server: Data<Arc<FindexServer>>,
 ) -> ResponseBytes {
     const OPERATION_NAME: &str = "guarded_write";
+    const INVALID_REQUEST: &str = "Invalid request.";
     let user = findex_server.get_user(&req);
 
     trace!("user {user}: POST /indexes/{index_id}/guarded_write");
@@ -101,9 +102,10 @@ pub(crate) async fn findex_guarded_write(
             }
         }
     } else {
-        return Err(FindexServerError::InvalidRequest(format!(
-            "{error_prefix} Invalid discriminant flag. Expected 0 or 1, found None"
-        )));
+        trace!("{error_prefix} Invalid discriminant flag. Expected 0 or 1, found None");
+        return Err(FindexServerError::InvalidRequest(
+            INVALID_REQUEST.to_owned(),
+        ));
     };
 
     let guard = Guard::deserialize(bytes.get(..guard_len).ok_or_else(|| {


### PR DESCRIPTION

- [x] Upgrade findex to the v7 version but keep the same usages of the server
- [x] Purge cloudproof : delete **all** cloudproof imports and references, replacing them with direct import from findex repo when necessary
- [x] Make sure the DB operations are atomic **and** asyncronous. For reference, a PR is made on the redis crate : https://github.com/redis-rs/redis-rs/pull/1485
- [x] Minor coding style updates
- [x] Create a serialization for findex structs <=> byte streams. Write unit tests for those operations. All this is centralized under `crate/structs` . This will be optimized later on : https://github.com/Cosmian/findex-server/issues/29
