### PR TITLE
feat: change transactions code, no mutex

### DIFF
--- a/crate/cli/src/actions/permissions.rs
+++ b/crate/cli/src/actions/permissions.rs
@@ -10,7 +10,7 @@ use crate::error::result::{CliResult, CliResultHelper};
 pub enum PermissionsAction {
     Create(CreateIndex),
     List(ListPermissions),
-    Grant(GrantPermission),
+    Set(SetPermission),
     Revoke(RevokePermission),
 }
 
@@ -30,7 +30,7 @@ impl PermissionsAction {
                 .run(rest_client)
                 .await
                 .map(|permissions| format!("Permissions: {permissions}")),
-            Self::Grant(action) => action.run(rest_client).await,
+            Self::Set(action) => action.run(rest_client).await,
             Self::Revoke(action) => action.run(rest_client).await,
         }
     }
@@ -88,16 +88,16 @@ impl ListPermissions {
     }
 }
 
-/// Grant permission on a index.
+/// Set permission on a index.
 ///
 /// This command can only be called by the owner of the index. It allows to
-/// grant:
+/// set:
 /// * `read` permission: the user can only read the index
 /// * `write` permission: the user can read and write the index
-/// * `admin` permission: the user can read, write and grant permission to the
+/// * `admin` permission: the user can read, write and set permission to the
 ///   index
 #[derive(Parser, Debug)]
-pub struct GrantPermission {
+pub struct SetPermission {
     /// The user identifier to allow
     #[clap(long, required = true)]
     pub user: String,
@@ -110,17 +110,17 @@ pub struct GrantPermission {
     pub permission: Permission,
 }
 
-impl GrantPermission {
-    /// Runs the `GrantPermission` action.
+impl SetPermission {
+    /// Runs the `SetPermission` action.
     ///
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
     pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
         let response = rest_client
-            .grant_permission(&self.user, &self.permission, &self.index_id)
+            .set_permission(&self.user, &self.permission, &self.index_id)
             .await
-            .with_context(|| "Can't execute the grant permission query on the findex server")?;
+            .with_context(|| "Can't execute the set permission query on the findex server")?;
 
         Ok(response.success)
     }

--- a/crate/cli/src/tests/findex_tests.rs
+++ b/crate/cli/src/tests/findex_tests.rs
@@ -15,7 +15,7 @@ use crate::{
         insert_or_delete::InsertOrDeleteAction, parameters::FindexParameters, search::SearchAction,
     },
     error::result::CliResult,
-    tests::permissions::{create_index_id, grant_permission, list_permission, revoke_permission},
+    tests::permissions::{create_index_id, list_permission, revoke_permission, set_permission},
 };
 
 use super::search_options::SearchOptions;
@@ -176,7 +176,7 @@ pub(crate) async fn test_findex_cert_auth() -> CliResult<()> {
 }
 
 #[tokio::test]
-pub(crate) async fn test_findex_grant_and_revoke_permission() -> CliResult<()> {
+pub(crate) async fn test_findex_set_and_revoke_permission() -> CliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server_with_cert_auth().await;
     let owner_conf = FindexClientConfig::load(Some(PathBuf::from(&ctx.owner_client_conf_path)))?;
@@ -212,8 +212,7 @@ pub(crate) async fn test_findex_grant_and_revoke_permission() -> CliResult<()> {
     .insert(&mut owner_rest_client)
     .await?;
 
-    // Grant read permission to the client
-    grant_permission(
+    set_permission(
         &owner_rest_client,
         "user.client@acme.com".to_owned(),
         index_id,
@@ -248,8 +247,7 @@ pub(crate) async fn test_findex_grant_and_revoke_permission() -> CliResult<()> {
     .await
     .unwrap_err();
 
-    // Grant write permission
-    grant_permission(
+    set_permission(
         &owner_rest_client,
         "user.client@acme.com".to_owned(),
         index_id,
@@ -287,7 +285,7 @@ pub(crate) async fn test_findex_grant_and_revoke_permission() -> CliResult<()> {
     .await?;
 
     // Try to escalade privileges from `read` to `admin`
-    grant_permission(
+    set_permission(
         &user_rest_client,
         "user.client@acme.com".to_owned(),
         index_id,

--- a/crate/cli/src/tests/permissions.rs
+++ b/crate/cli/src/tests/permissions.rs
@@ -3,7 +3,7 @@ use cosmian_findex_structs::Permission;
 use uuid::Uuid;
 
 use crate::{
-    actions::permissions::{CreateIndex, GrantPermission, ListPermissions, RevokePermission},
+    actions::permissions::{CreateIndex, ListPermissions, RevokePermission, SetPermission},
     error::result::CliResult,
 };
 
@@ -18,13 +18,13 @@ pub(crate) async fn list_permission(
     ListPermissions { user }.run(rest_client).await
 }
 
-pub(crate) async fn grant_permission(
+pub(crate) async fn set_permission(
     rest_client: &FindexRestClient,
     user: String,
     index_id: Uuid,
     permission: Permission,
 ) -> CliResult<String> {
-    GrantPermission {
+    SetPermission {
         user,
         index_id,
         permission,

--- a/crate/client/src/permissions.rs
+++ b/crate/client/src/permissions.rs
@@ -22,13 +22,13 @@ impl FindexRestClient {
     }
 
     #[instrument(ret(Display), err, skip(self), level = "trace")]
-    pub async fn grant_permission(
+    pub async fn set_permission(
         &self,
         user_id: &str,
         permission: &Permission,
         index_id: &Uuid,
     ) -> FindexClientResult<SuccessResponse> {
-        let endpoint = format!("/permission/grant/{user_id}/{permission}/{index_id}");
+        let endpoint = format!("/permission/set/{user_id}/{permission}/{index_id}");
         let server_url = format!("{}{endpoint}", self.http_client.server_url);
         trace!("POST: {server_url}");
         let response = self.http_client.client.post(server_url).send().await?;

--- a/crate/server/src/core/implementation.rs
+++ b/crate/server/src/core/implementation.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::{
     config::{DbParams, ServerParams},
     database::{database_traits::PermissionsTrait, redis::Redis},
-    error::result::FResult,
+    error::{result::FResult, server::FindexServerError},
     middlewares::{JwtAuthClaim, PeerCommonName},
 };
 pub(crate) struct FindexServer {
@@ -58,7 +58,6 @@ impl FindexServer {
         user
     }
 
-    // #[instrument(ret(Display), err, skip(self))]
     pub(crate) async fn get_permission(
         &self,
         user_id: &str,
@@ -75,5 +74,21 @@ impl FindexServer {
         let permission = self.db.get_permission(user_id, &index_id).await?;
         trace!("User {user_id} has: {permission}");
         Ok(permission)
+    }
+
+    pub(crate) async fn check_permission(
+        &self,
+        user: &str,
+        index_id: &str,
+        expected_permission: Permission,
+    ) -> FResult<()> {
+        let permission = self.get_permission(user, index_id).await?;
+        trace!("check_permission: user {user} has permission {permission} on index {index_id}");
+        if permission < expected_permission {
+            return Err(FindexServerError::Unauthorized(format!(
+                "User {user} with permission {permission} is not allowed to write on index {index_id}",
+            )));
+        }
+        Ok(())
     }
 }

--- a/crate/server/src/core/implementation.rs
+++ b/crate/server/src/core/implementation.rs
@@ -76,14 +76,14 @@ impl FindexServer {
         Ok(permission)
     }
 
-    pub(crate) async fn check_permission(
+    pub(crate) async fn ensure_minimum_permission(
         &self,
         user: &str,
         index_id: &str,
         expected_permission: Permission,
     ) -> FResult<()> {
         let permission = self.get_permission(user, index_id).await?;
-        trace!("check_permission: user {user} has permission {permission} on index {index_id}");
+        trace!("ensure_minimum_permission: user {user} has permission {permission} on index {index_id}");
         if permission < expected_permission {
             return Err(FindexServerError::Unauthorized(format!(
                 "User {user} with permission {permission} is not allowed to write on index {index_id}",

--- a/crate/server/src/database/database_traits.rs
+++ b/crate/server/src/database/database_traits.rs
@@ -19,6 +19,12 @@ pub(crate) trait PermissionsTrait: Sync + Send {
         index_id: &Uuid,
     ) -> FResult<()>;
     async fn revoke_permission(&self, user_id: &str, index_id: &Uuid) -> FResult<()>;
+    async fn _check_permission(
+        &self,
+        user_id: &str,
+        index_id: &Uuid,
+        expected_permission: Permission,
+    ) -> FResult<bool>;
 }
 
 #[async_trait]

--- a/crate/server/src/database/database_traits.rs
+++ b/crate/server/src/database/database_traits.rs
@@ -19,12 +19,6 @@ pub(crate) trait PermissionsTrait: Sync + Send {
         index_id: &Uuid,
     ) -> FResult<()>;
     async fn revoke_permission(&self, user_id: &str, index_id: &Uuid) -> FResult<()>;
-    async fn _check_permission(
-        &self,
-        user_id: &str,
-        index_id: &Uuid,
-        expected_permission: Permission,
-    ) -> FResult<bool>;
 }
 
 #[async_trait]

--- a/crate/server/src/database/database_traits.rs
+++ b/crate/server/src/database/database_traits.rs
@@ -12,7 +12,7 @@ pub(crate) trait PermissionsTrait: Sync + Send {
     async fn create_index_id(&self, user_id: &str) -> FResult<Uuid>;
     async fn get_permissions(&self, user_id: &str) -> FResult<Permissions>;
     async fn get_permission(&self, user_id: &str, index_id: &Uuid) -> FResult<Permission>;
-    async fn grant_permission(
+    async fn set_permission(
         &self,
         user_id: &str,
         permission: Permission,

--- a/crate/server/src/database/redis/instance.rs
+++ b/crate/server/src/database/redis/instance.rs
@@ -7,7 +7,6 @@ use tracing::info;
 pub(crate) struct Redis<const WORD_LENGTH: usize> {
     pub(crate) memory: RedisMemory<Address<SERVER_ADDRESS_LENGTH>, [u8; WORD_LENGTH]>,
     pub(crate) manager: ConnectionManager,
-    // pub(crate) lock: Mutex<()>,
 }
 
 impl<const WORD_LENGTH: usize> Redis<WORD_LENGTH> {
@@ -29,10 +28,6 @@ impl<const WORD_LENGTH: usize> Redis<WORD_LENGTH> {
 
         let memory = RedisMemory::connect_with_manager(manager.clone()).await?;
 
-        Ok(Self {
-            memory,
-            manager,
-            // lock: Mutex::new(()),
-        })
+        Ok(Self { memory, manager })
     }
 }

--- a/crate/server/src/database/redis/instance.rs
+++ b/crate/server/src/database/redis/instance.rs
@@ -2,13 +2,12 @@ use crate::error::{result::FResult, server::FindexServerError};
 use cosmian_findex::{Address, RedisMemory};
 use cosmian_findex_structs::SERVER_ADDRESS_LENGTH;
 use redis::aio::ConnectionManager;
-use tokio::sync::Mutex;
 use tracing::info;
 
 pub(crate) struct Redis<const WORD_LENGTH: usize> {
     pub(crate) memory: RedisMemory<Address<SERVER_ADDRESS_LENGTH>, [u8; WORD_LENGTH]>,
     pub(crate) manager: ConnectionManager,
-    pub(crate) lock: Mutex<()>,
+    // pub(crate) lock: Mutex<()>,
 }
 
 impl<const WORD_LENGTH: usize> Redis<WORD_LENGTH> {
@@ -33,7 +32,7 @@ impl<const WORD_LENGTH: usize> Redis<WORD_LENGTH> {
         Ok(Self {
             memory,
             manager,
-            lock: Mutex::new(()),
+            // lock: Mutex::new(()),
         })
     }
 }

--- a/crate/server/src/database/redis/permissions.rs
+++ b/crate/server/src/database/redis/permissions.rs
@@ -62,7 +62,7 @@ impl PermissionsTrait for Redis<WORD_LENGTH> {
             .map(|(index_str, perm)| {
                 Ok((
                     Uuid::parse_str(&index_str).map_err(|e| {
-                        FindexServerError::DatabaseError(format!("Invalid UUID. {e}"))
+                        FindexServerError::DatabaseError(format!("Invalid index ID. {e}"))
                     })?,
                     Permission::try_from(perm).map_err(|e| {
                         FindexServerError::DatabaseError(format!("Invalid permission. {e}"))
@@ -86,7 +86,9 @@ impl PermissionsTrait for Redis<WORD_LENGTH> {
             .await
             .map_err(FindexServerError::from)?
             .ok_or_else(|| {
-                FindexServerError::Unauthorized(format!("No permission found for index {index_id}"))
+                FindexServerError::DatabaseError(format!(
+                    "No permission found for index {index_id}"
+                ))
             })
             .and_then(|p| {
                 Permission::try_from(p).map_err(|e| {

--- a/crate/server/src/findex_server.rs
+++ b/crate/server/src/findex_server.rs
@@ -22,8 +22,8 @@ use crate::{
     middlewares::{extract_peer_certificate, AuthTransformer, JwksManager, JwtConfig, SslAuth},
     routes::{
         create_index_id, datasets_add_entries, datasets_del_entries, datasets_get_entries,
-        findex_batch_read, findex_guarded_write, get_version, grant_permission, list_permission,
-        revoke_permission,
+        findex_batch_read, findex_guarded_write, get_version, list_permission, revoke_permission,
+        set_permission,
     },
 };
 
@@ -254,7 +254,7 @@ pub(crate) async fn prepare_findex_server(
             // Permissions management endpoints
             .service(create_index_id)
             .service(list_permission)
-            .service(grant_permission)
+            .service(set_permission)
             .service(revoke_permission)
             // Dataset management
             .service(datasets_add_entries)

--- a/crate/server/src/routes/datasets.rs
+++ b/crate/server/src/routes/datasets.rs
@@ -29,7 +29,7 @@ pub(crate) async fn datasets_add_entries(
     info!("user {user}: POST /datasets/{index_id}/add_entries");
 
     findex_server
-        .check_permission(&user, &index_id, Permission::Write)
+        .ensure_minimum_permission(&user, &index_id, Permission::Write)
         .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;
@@ -66,7 +66,7 @@ pub(crate) async fn datasets_del_entries(
     info!("user {user}: POST /datasets/{index_id}/delete_entries");
 
     findex_server
-        .check_permission(&user, &index_id, Permission::Write)
+        .ensure_minimum_permission(&user, &index_id, Permission::Write)
         .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;
@@ -103,7 +103,7 @@ pub(crate) async fn datasets_get_entries(
     info!("user {user}: POST /datasets/{index_id}/get_entries",);
 
     findex_server
-        .check_permission(&user, &index_id, Permission::Read)
+        .ensure_minimum_permission(&user, &index_id, Permission::Read)
         .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;

--- a/crate/server/src/routes/datasets.rs
+++ b/crate/server/src/routes/datasets.rs
@@ -14,10 +14,7 @@ use crate::{
     core::FindexServer,
     database::database_traits::DatasetsTrait,
     error::result::FResult,
-    routes::{
-        check_permission,
-        error::{ResponseBytes, SuccessResponse},
-    },
+    routes::error::{ResponseBytes, SuccessResponse},
 };
 
 #[post("/datasets/{index_id}/add_entries")]
@@ -31,7 +28,9 @@ pub(crate) async fn datasets_add_entries(
 
     info!("user {user}: POST /datasets/{index_id}/add_entries");
 
-    check_permission(&user, &index_id, Permission::Write, &findex_server).await?;
+    findex_server
+        .check_permission(&user, &index_id, Permission::Write)
+        .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;
     let encrypted_entries = EncryptedEntries::deserialize(&bytes)?;
@@ -66,7 +65,9 @@ pub(crate) async fn datasets_del_entries(
 
     info!("user {user}: POST /datasets/{index_id}/delete_entries");
 
-    check_permission(&user, &index_id, Permission::Write, &findex_server).await?;
+    findex_server
+        .check_permission(&user, &index_id, Permission::Write)
+        .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;
     let uuids = Uuids::deserialize(&bytes)?;
@@ -101,7 +102,9 @@ pub(crate) async fn datasets_get_entries(
 
     info!("user {user}: POST /datasets/{index_id}/get_entries",);
 
-    check_permission(&user, &index_id, Permission::Read, &findex_server).await?;
+    findex_server
+        .check_permission(&user, &index_id, Permission::Read)
+        .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;
     let uuids = Uuids::deserialize(&bytes)?;

--- a/crate/server/src/routes/findex.rs
+++ b/crate/server/src/routes/findex.rs
@@ -39,7 +39,7 @@ pub(crate) async fn findex_batch_read(
     trace!("user {user}: POST /indexes/{index_id}/batch_read");
 
     findex_server
-        .check_permission(&user, &index_id, Permission::Read)
+        .ensure_minimum_permission(&user, &index_id, Permission::Read)
         .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;
@@ -79,7 +79,7 @@ pub(crate) async fn findex_guarded_write(
     trace!("user {user}: POST /indexes/{index_id}/guarded_write");
 
     findex_server
-        .check_permission(&user, &index_id, Permission::Write)
+        .ensure_minimum_permission(&user, &index_id, Permission::Write)
         .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;

--- a/crate/server/src/routes/findex.rs
+++ b/crate/server/src/routes/findex.rs
@@ -14,13 +14,7 @@ use cosmian_findex_structs::{
 use tracing::trace;
 use uuid::Uuid;
 
-use crate::{
-    core::FindexServer,
-    error::server::FindexServerError,
-    routes::{check_permission, error::ResponseBytes},
-};
-
-// TODO(hatem): reduce cloning
+use crate::{core::FindexServer, error::server::FindexServerError, routes::error::ResponseBytes};
 
 #[allow(clippy::indexing_slicing)]
 fn prepend_index_id(
@@ -44,7 +38,9 @@ pub(crate) async fn findex_batch_read(
 
     trace!("user {user}: POST /indexes/{index_id}/batch_read");
 
-    check_permission(&user, &index_id, Permission::Read, &findex_server).await?;
+    findex_server
+        .check_permission(&user, &index_id, Permission::Read)
+        .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;
     let addresses = Addresses::deserialize(&bytes)?
@@ -82,7 +78,9 @@ pub(crate) async fn findex_guarded_write(
 
     trace!("user {user}: POST /indexes/{index_id}/guarded_write");
 
-    check_permission(&user, &index_id, Permission::Write, &findex_server).await?;
+    findex_server
+        .check_permission(&user, &index_id, Permission::Write)
+        .await?;
 
     let index_id = Uuid::parse_str(&index_id)?;
 

--- a/crate/server/src/routes/mod.rs
+++ b/crate/server/src/routes/mod.rs
@@ -6,7 +6,5 @@ mod version;
 
 pub(crate) use datasets::{datasets_add_entries, datasets_del_entries, datasets_get_entries};
 pub(crate) use findex::{findex_batch_read, findex_guarded_write};
-pub(crate) use permissions::{
-    create_index_id, grant_permission, list_permission, revoke_permission,
-};
+pub(crate) use permissions::{create_index_id, list_permission, revoke_permission, set_permission};
 pub(crate) use version::get_version;

--- a/crate/server/src/routes/mod.rs
+++ b/crate/server/src/routes/mod.rs
@@ -7,6 +7,6 @@ mod version;
 pub(crate) use datasets::{datasets_add_entries, datasets_del_entries, datasets_get_entries};
 pub(crate) use findex::{findex_batch_read, findex_guarded_write};
 pub(crate) use permissions::{
-    check_permission, create_index_id, grant_permission, list_permission, revoke_permission,
+    create_index_id, grant_permission, list_permission, revoke_permission,
 };
 pub(crate) use version::get_version;

--- a/crate/server/src/routes/permissions.rs
+++ b/crate/server/src/routes/permissions.rs
@@ -15,22 +15,6 @@ use std::{str::FromStr, sync::Arc};
 use tracing::trace;
 use uuid::Uuid;
 
-pub(crate) async fn check_permission(
-    user: &str,
-    index_id: &str,
-    expected_permission: Permission,
-    findex_server: &FindexServer,
-) -> FResult<()> {
-    let permission = findex_server.get_permission(user, index_id).await?;
-    trace!("check_permission: user {user} has permission {permission} on index {index_id}");
-    if permission < expected_permission {
-        return Err(FindexServerError::Unauthorized(format!(
-            "User {user} with permission {permission} is not allowed to write on index {index_id}",
-        )));
-    }
-    Ok(())
-}
-
 #[post("/create/index")]
 pub(crate) async fn create_index_id(
     req: HttpRequest,

--- a/crate/server/src/routes/permissions.rs
+++ b/crate/server/src/routes/permissions.rs
@@ -31,22 +31,22 @@ pub(crate) async fn create_index_id(
     }))
 }
 
-#[post("/permission/grant/{user_id}/{permission}/{index_id}")]
-pub(crate) async fn grant_permission(
+#[post("/permission/set/{user_id}/{permission}/{index_id}")]
+pub(crate) async fn set_permission(
     req: HttpRequest,
     params: web::Path<(String, String, String)>,
     findex_server: Data<Arc<FindexServer>>,
 ) -> FResult<Json<SuccessResponse>> {
     let user = findex_server.get_user(&req);
     let (user_id, permission, index_id) = params.into_inner();
-    trace!("user {user}: POST /permission/grant/{user_id}/{permission}/{index_id}");
+    trace!("user {user}: POST /permission/set/{user_id}/{permission}/{index_id}");
 
-    // Check if the user has the right to grant permission: only admins can do that
+    // Check if the user has the right to set permission: only admins can do that
     let user_permission = findex_server.get_permission(&user, &index_id).await?;
     if Permission::Admin != user_permission {
         return Err(FindexServerError::Unauthorized(format!(
             "Delegating permission to an index requires an admin permission. User {user} with \
-             permission {user_permission} does not allow granting permission to index {index_id} \
+             permission {user_permission} does not allow setting permission to index {index_id} \
              with permission {permission}",
         )));
     }
@@ -56,7 +56,7 @@ pub(crate) async fn grant_permission(
 
     findex_server
         .db
-        .grant_permission(
+        .set_permission(
             &user_id,
             Permission::from_str(permission.as_str())?,
             &index_id,

--- a/crate/structs/src/permissions.rs
+++ b/crate/structs/src/permissions.rs
@@ -8,7 +8,6 @@ use crate::{
     structs_bail,
 };
 
-#[repr(u8)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub enum Permission {
     Read = 0,
@@ -141,7 +140,7 @@ impl Permissions {
         Self { permissions }
     }
 
-    pub fn grant_permission(&mut self, index_id: Uuid, permission: Permission) {
+    pub fn set_permission(&mut self, index_id: Uuid, permission: Permission) {
         self.permissions.insert(index_id, permission);
     }
 

--- a/crate/structs/src/permissions.rs
+++ b/crate/structs/src/permissions.rs
@@ -90,7 +90,7 @@ impl FromIterator<(Uuid, Permission)> for Permissions {
         for (uuid, permission) in iter {
             permissions.insert(uuid, permission);
         }
-        Permissions { permissions }
+        Self { permissions }
     }
 }
 

--- a/crate/structs/src/permissions.rs
+++ b/crate/structs/src/permissions.rs
@@ -84,6 +84,16 @@ impl Display for Permissions {
     }
 }
 
+impl FromIterator<(Uuid, Permission)> for Permissions {
+    fn from_iter<I: IntoIterator<Item = (Uuid, Permission)>>(iter: I) -> Self {
+        let mut permissions = HashMap::new();
+        for (uuid, permission) in iter {
+            permissions.insert(uuid, permission);
+        }
+        Permissions { permissions }
+    }
+}
+
 impl Serializable for Permissions {
     type Error = StructsError;
 

--- a/crate/structs/src/permissions.rs
+++ b/crate/structs/src/permissions.rs
@@ -8,7 +8,7 @@ use crate::{
     structs_bail,
 };
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Permission {
     Read = 0,
     Write = 1,
@@ -111,7 +111,7 @@ impl Serializable for Permissions {
     fn write(&self, ser: &mut bytes_ser_de::Serializer) -> Result<usize, Self::Error> {
         let mut n = ser.write_leb128_u64(u64::try_from(self.permissions.len())?)?;
         for (index_id, permission) in &self.permissions {
-            n += ser.write_leb128_u64(u64::from(u8::from(permission.clone())))?;
+            n += ser.write_leb128_u64(u64::from(u8::from(*permission)))?;
             n += ser.write_array(index_id.as_bytes())?;
         }
         Ok(n)
@@ -158,10 +158,7 @@ impl Permissions {
         let mut permissions = HashMap::with_capacity(self.permissions.len());
         for (index_id, permission) in &self.permissions {
             if let Some(other_permission) = other_permissions.permissions.get(index_id) {
-                permissions.insert(
-                    *index_id,
-                    std::cmp::min(permission.clone(), other_permission.clone()),
-                );
+                permissions.insert(*index_id, std::cmp::min(*permission, *other_permission));
             }
         }
         Self { permissions }

--- a/documentation/docs/authorization.md
+++ b/documentation/docs/authorization.md
@@ -24,7 +24,7 @@ sequenceDiagram
   User->>F: User authentication
   User->>F: User create an Index ID
   F->>User: Index ID with admin permission
-  User->>F: User grant/revoke permission to another user
+  User->>F: User set/revoke permission to another user
 ```
 
 There are 3 permissions:
@@ -35,7 +35,7 @@ There are 3 permissions:
 
 The mechanism is pretty simple:
 
-When a user creates a new **Index ID**, he becomes the **admin** of this index. He can then grant other index users the role of **reader**, **writer** or **admin**.
+When a user creates a new **Index ID**, he becomes the **admin** of this index. He can then set other index users the role of **reader**, **writer** or **admin**.
 
 Every server endpoint is protected by this authorization mechanism: the server checks the user's role before allowing access to the endpoint.
 
@@ -45,15 +45,15 @@ Currently, there is an entry for each user in database. In the case of a key-val
 
 #### Example
 
-| Key              | Value                                                                                          |
-| ---------------- | ---------------------------------------------------------------------------------------------- |
+| Key              | Value                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------ |
 | `user@gmail.com` | (0,d9eee59c-f9df-4edd-97bc-ba5952ce63af) \| (1,5b044b87-bced-424c-9dac-f25550c88c20) |
 
 ## Endpoints
 
-| Endpoint                                              | Description                                       |
-| ----------------------------------------------------- | ------------------------------------------------- |
-| `/create/index`                                       | Create an **Index ID**                            |
-| `/permission/grant/{user_id}/{permission}/{index_id}` | Grant a permission to a user for a specific index |
-| `/permission/list/{user_id}`                          | List permissions of a user                        |
-| `/permission/revoke/{user_id}/{index_id}`             | Revoke a user's permission for a specific index   |
+| Endpoint                                            | Description                                     |
+| --------------------------------------------------- | ----------------------------------------------- |
+| `/create/index`                                     | Create an **Index ID**                          |
+| `/permission/set/{user_id}/{permission}/{index_id}` | Set a permission to a user for a specific index |
+| `/permission/list/{user_id}`                        | List permissions of a user                      |
+| `/permission/revoke/{user_id}/{index_id}`           | Revoke a user's permission for a specific index |


### PR DESCRIPTION
# Overview : 

New code for permission handling.
This new approach does : 
- Atomic operations, acheiving true concurrency
- Does not need transactions, all operations are done in a single command & a single network round trip
- Does not need the usage of a Mutex or similar locks, rip Mutex

Below is what each function sends as command to the redis DB : 


## create_index_id & grant_permission

`HSET user:permissions:{user_id} {index_id} {permission}`

~~will be refactored to reduce duplication~~ Was not refactored because this will mess up the logging and might require a small change in function signatures for a very minor and trivial code, so it's better this way.


##  get_permissionS

`HGETALL user:permissions:{user_id}`

##  get_permission
`
HGET user:permissions:{user_id} {index_id}
`
##  revoke_permission
`
HDEL user:permissions:{user_id} {index_id}`

## Additionnal info :

- if we need to find users for a given index, we can create an inverse mapping and wrap it with a MULTI/EXEC block. So far, nowhere in the codebase we need this, so I did not includ the reverse indexing (but tested to work).

- there is a change in the integration test : since no locks are used the operations will now be permormed in a purely random order (which is exactly what a real life scenario would be). So it's not theoretically possible to predict "the order" on which everything will happen ( unless we put locks back).

So instead, we test the final state for each thread (which is actually predictable).

## Performance :

The integration test `test_permissions_concurrent_grand_revoke_permissions` is the best to showcase  a performance improvement. We will set it to :

```
 test_permissions_concurrent_grand_revoke_permissions() {
        const MAX_USERS: usize = 1000;
        const MAX_OPS: usize = 1000;
```
#### New version
test result: ok. 1 passed ... finished in 23.35s

#### Previous version
ran for more than 10min, froze the system (ubuntu) and caused a crash ( only reproduce this on high end devices to avoid data loss )