### PR TITLE
feat: semaphore for CLI parallelism

### DIFF
--- a/crate/cli/src/actions/findex/insert_or_delete.rs
+++ b/crate/cli/src/actions/findex/insert_or_delete.rs
@@ -83,7 +83,10 @@ impl InsertOrDeleteAction {
                 let findex = findex.clone();
                 let semaphore = semaphore.clone();
                 tokio::spawn(async move {
-                    let _permit = semaphore.acquire().await;
+                    let _permit = semaphore
+                        .acquire()
+                        .await
+                        .map_err(|e| cosmian_findex::Error::Conversion(e.to_string()))?;
                     if is_insert {
                         findex.insert(kw, vs).await
                     } else {

--- a/crate/cli/src/actions/findex/insert_or_delete.rs
+++ b/crate/cli/src/actions/findex/insert_or_delete.rs
@@ -80,7 +80,7 @@ impl InsertOrDeleteAction {
         let operation_name = if is_insert { "Indexing" } else { "Deleting" };
         let output = format!("Indexing done: keywords: {written_keywords:?}");
 
-        let semaphore = Arc::new(Semaphore::new(10));
+        let semaphore = Arc::new(Semaphore::new(30));
 
         let handles = bindings
             .0

--- a/crate/cli/src/actions/findex/mod.rs
+++ b/crate/cli/src/actions/findex/mod.rs
@@ -6,4 +6,4 @@ pub mod search;
 /// Each network call opens a socket which consumes a file descriptor. While the system's file descriptor
 /// limit can be configured (via `ulimit -n` or `/etc/security/limits.conf`), we enforce this fixed limit
 /// which is the default soft limit on many Linux systems to ensure consistent behavior.
-pub(crate) const MAX_PERMITS: usize = 256;
+pub(crate) const MAX_PERMITS: usize = 512;

--- a/crate/cli/src/actions/findex/mod.rs
+++ b/crate/cli/src/actions/findex/mod.rs
@@ -1,4 +1,9 @@
 pub mod insert_or_delete;
 pub mod parameters;
 pub mod search;
-pub(crate) const MAX_SEMAPHORES: usize = 1024; // base value for most linux kernels
+/// Maximum number of concurrent network calls allowed per CLI findex-command invocation.
+///
+/// Each network call opens a socket which consumes a file descriptor. While the system's file descriptor
+/// limit can be configured (via `ulimit -n` or `/etc/security/limits.conf`), we enforce this fixed limit
+/// which is the default soft limit on many Linux systems to ensure consistent behavior.
+pub(crate) const MAX_PERMITS: usize = 1024;

--- a/crate/cli/src/actions/findex/mod.rs
+++ b/crate/cli/src/actions/findex/mod.rs
@@ -1,5 +1,4 @@
 pub mod insert_or_delete;
 pub mod parameters;
 pub mod search;
-
-pub(crate) const MAX_SEMAPHORES:usize = 1024; // base value for most linux kernels
+pub(crate) const MAX_SEMAPHORES: usize = 1024; // base value for most linux kernels

--- a/crate/cli/src/actions/findex/mod.rs
+++ b/crate/cli/src/actions/findex/mod.rs
@@ -6,4 +6,4 @@ pub mod search;
 /// Each network call opens a socket which consumes a file descriptor. While the system's file descriptor
 /// limit can be configured (via `ulimit -n` or `/etc/security/limits.conf`), we enforce this fixed limit
 /// which is the default soft limit on many Linux systems to ensure consistent behavior.
-pub(crate) const MAX_PERMITS: usize = 1024;
+pub(crate) const MAX_PERMITS: usize = 256;

--- a/crate/cli/src/actions/findex/mod.rs
+++ b/crate/cli/src/actions/findex/mod.rs
@@ -1,3 +1,5 @@
 pub mod insert_or_delete;
 pub mod parameters;
 pub mod search;
+
+pub(crate) const MAX_SEMAPHORES:usize = 1024; // base value for most linux kernels

--- a/crate/cli/src/actions/findex/mod.rs
+++ b/crate/cli/src/actions/findex/mod.rs
@@ -5,5 +5,5 @@ pub mod search;
 ///
 /// Each network call opens a socket which consumes a file descriptor. While the system's file descriptor
 /// limit can be configured (via `ulimit -n` or `/etc/security/limits.conf`), we enforce this fixed limit
-/// which is the default soft limit on many Linux systems to ensure consistent behavior.
-pub(crate) const MAX_PERMITS: usize = 512;
+/// to ensure consistent behavior, but it can be tuned according to the system.
+pub(crate) const MAX_PERMITS: usize = 256;

--- a/crate/cli/src/actions/findex/search.rs
+++ b/crate/cli/src/actions/findex/search.rs
@@ -42,7 +42,10 @@ impl SearchAction {
                 let semaphore = semaphore.clone();
                 let findex_instance = findex_instance.clone();
                 tokio::spawn(async move {
-                    let _permit = semaphore.acquire().await;
+                    let _permit = semaphore
+                        .acquire()
+                        .await
+                        .map_err(|e| cosmian_findex::Error::Conversion(e.to_string()))?;
                     findex_instance.search(&k).await
                 })
             })

--- a/crate/cli/src/actions/findex/search.rs
+++ b/crate/cli/src/actions/findex/search.rs
@@ -46,7 +46,6 @@ impl SearchAction {
                     findex_instance.search(&k).await
                 })
             })
-            .ok_or_else(|| CliError::Default("No search handles available".to_owned()))?
             .collect::<Vec<_>>();
 
         let mut acc_results = handles


### PR DESCRIPTION
## Overview : 

- [x] Parallellized the insert/delete/search findex operation on the CLI side, leading to **double** the test execution speed. The max semaphore number is (currently) set to 1024 but we can consider to augement it we see that fit.
- [x] Reduced string cloning
- [x] optimize search function by agregating redundant iterations and early returning when necessary
- ~~[ ] use futures::join_all~~ : moved to this PR because of very poor performance ( around 120s for huge dataset test ) -> https://github.com/Cosmian/findex-server/pull/48

____________________________________________________

( tests were done in an empiric manner )

### Insert and delete :

By using semaphores, we can double the program speed. The benchmarking reference will be "huge_dataset" test

So far the perf is double what it was, from 59sec to 30sec

![image](https://github.com/user-attachments/assets/925eda63-dc33-4acc-80f7-fa11962c6069)


### Search : 

By not using a semaphore, the test takes 36 seconds.