### PR TITLE
Feat/reduce cloning

### DIFF
--- a/crate/cli/src/actions/datasets.rs
+++ b/crate/cli/src/actions/datasets.rs
@@ -25,7 +25,7 @@ impl DatasetsAction {
     /// # Errors
     ///
     /// Returns an error if one of Add, Delete of Get actions fails
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         match self {
             Self::Add(action) => action.run(rest_client).await,
             Self::Delete(action) => action.run(rest_client).await,
@@ -74,7 +74,7 @@ impl AddEntries {
     /// Returns an error if the query execution on the Findex server fails.
     /// Returns an error if the base64 decoding fails.
     /// Returns an error if the UUID parsing fails.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let encrypted_entries = self.entries.iter().try_fold(
             HashMap::with_capacity(self.entries.len()),
             |mut acc, (key, value)| {
@@ -111,7 +111,7 @@ impl DeleteEntries {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .delete_entries(&self.index_id, &self.uuids)
             .await
@@ -140,7 +140,7 @@ impl GetEntries {
     ///
     /// Returns an error if the query execution on the Findex server fails.
     /// Returns an error if the UUID parsing fails.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<EncryptedEntries> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<EncryptedEntries> {
         let encrypted_entries = rest_client
             .get_entries(&self.index_id, &self.uuids)
             .await

--- a/crate/cli/src/actions/datasets.rs
+++ b/crate/cli/src/actions/datasets.rs
@@ -25,7 +25,7 @@ impl DatasetsAction {
     /// # Errors
     ///
     /// Returns an error if one of Add, Delete of Get actions fails
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
         match self {
             Self::Add(action) => action.run(rest_client).await,
             Self::Delete(action) => action.run(rest_client).await,
@@ -74,7 +74,7 @@ impl AddEntries {
     /// Returns an error if the query execution on the Findex server fails.
     /// Returns an error if the base64 decoding fails.
     /// Returns an error if the UUID parsing fails.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
         let encrypted_entries = self.entries.iter().try_fold(
             HashMap::with_capacity(self.entries.len()),
             |mut acc, (key, value)| {
@@ -111,7 +111,7 @@ impl DeleteEntries {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .delete_entries(&self.index_id, &self.uuids)
             .await
@@ -140,7 +140,7 @@ impl GetEntries {
     ///
     /// Returns an error if the query execution on the Findex server fails.
     /// Returns an error if the UUID parsing fails.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<EncryptedEntries> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<EncryptedEntries> {
         let encrypted_entries = rest_client
             .get_entries(&self.index_id, &self.uuids)
             .await

--- a/crate/cli/src/actions/datasets.rs
+++ b/crate/cli/src/actions/datasets.rs
@@ -25,7 +25,7 @@ impl DatasetsAction {
     /// # Errors
     ///
     /// Returns an error if one of Add, Delete of Get actions fails
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         match self {
             Self::Add(action) => action.run(rest_client).await,
             Self::Delete(action) => action.run(rest_client).await,
@@ -74,7 +74,7 @@ impl AddEntries {
     /// Returns an error if the query execution on the Findex server fails.
     /// Returns an error if the base64 decoding fails.
     /// Returns an error if the UUID parsing fails.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let encrypted_entries = self.entries.iter().try_fold(
             HashMap::with_capacity(self.entries.len()),
             |mut acc, (key, value)| {
@@ -111,7 +111,7 @@ impl DeleteEntries {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .delete_entries(&self.index_id, &self.uuids)
             .await
@@ -140,7 +140,7 @@ impl GetEntries {
     ///
     /// Returns an error if the query execution on the Findex server fails.
     /// Returns an error if the UUID parsing fails.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<EncryptedEntries> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<EncryptedEntries> {
         let encrypted_entries = rest_client
             .get_entries(&self.index_id, &self.uuids)
             .await

--- a/crate/cli/src/actions/findex/insert_or_delete.rs
+++ b/crate/cli/src/actions/findex/insert_or_delete.rs
@@ -68,7 +68,6 @@ impl InsertOrDeleteAction {
 
         let findex: Arc<Findex<200, Value, String, FindexRestClient>> =
             Arc::<Findex<WORD_LENGTH, Value, String, FindexRestClient>>::new(
-                // cheap reference clone
                 rest_client.instantiate_findex(
                     self.findex_parameters.index_id,
                     &self.findex_parameters.seed()?,

--- a/crate/cli/src/actions/findex/insert_or_delete.rs
+++ b/crate/cli/src/actions/findex/insert_or_delete.rs
@@ -42,7 +42,7 @@ impl InsertOrDeleteAction {
     /// - The Findex instance cannot insert or delete the data.
     /// - The semaphore cannot acquire a permit.
     async fn insert_or_delete(
-        &self,
+        self,
         rest_client: FindexRestClient,
         is_insert: bool,
     ) -> CliResult<Keywords> {
@@ -84,7 +84,7 @@ impl InsertOrDeleteAction {
                 tokio::spawn(async move {
                     let _permit = semaphore.acquire().await.map_err(|e| {
                         CliError::Default(format!(
-                            "Acquire error while trying to ask for permit: {e:?}"
+                            "Acquire        config.save(conf_path.clone())?;        config.save(conf_path.clone())?; error while trying to ask for permit: {e:?}"
                         ))
                     })?;
                     if is_insert {
@@ -112,7 +112,7 @@ impl InsertOrDeleteAction {
     ///
     /// # Errors
     /// - If insert new indexes fails
-    pub async fn insert(&self, rest_client: FindexRestClient) -> CliResult<Keywords> {
+    pub async fn insert(self, rest_client: FindexRestClient) -> CliResult<Keywords> {
         Self::insert_or_delete(self, rest_client, true).await
     }
 
@@ -120,7 +120,7 @@ impl InsertOrDeleteAction {
     ///
     /// # Errors
     /// - If deleting indexes fails
-    pub async fn delete(&self, rest_client: FindexRestClient) -> CliResult<Keywords> {
+    pub async fn delete(self, rest_client: FindexRestClient) -> CliResult<Keywords> {
         Self::insert_or_delete(self, rest_client, false).await
     }
 }

--- a/crate/cli/src/actions/findex/insert_or_delete.rs
+++ b/crate/cli/src/actions/findex/insert_or_delete.rs
@@ -111,8 +111,8 @@ impl InsertOrDeleteAction {
         Self::insert_or_delete(self, rest_client, true)
             .await
             .map(|fmt| {
-                trace!("Insert done: keywords: {}", fmt);
-                format!("Inserted keywords: {}", fmt)
+                trace!("Insert done: keywords: {fmt}");
+                format!("Inserted keywords: {fmt}")
             })
     }
 
@@ -124,8 +124,8 @@ impl InsertOrDeleteAction {
         Self::insert_or_delete(self, rest_client, false)
             .await
             .map(|fmt| {
-                trace!("Delete done: keywords: {}", fmt);
-                format!("Deleted keywords: {}", fmt)
+                trace!("Delete done: keywords: {fmt}");
+                format!("Deleted keywords: {fmt}")
             })
     }
 }

--- a/crate/cli/src/actions/findex/insert_or_delete.rs
+++ b/crate/cli/src/actions/findex/insert_or_delete.rs
@@ -6,7 +6,7 @@ use crate::{
 use clap::Parser;
 use cosmian_findex::{Findex, IndexADT, Value};
 use cosmian_findex_client::FindexRestClient;
-use cosmian_findex_structs::{Keyword, Keywords, WORD_LENGTH};
+use cosmian_findex_structs::{Keyword, KeywordToDataSetsMap, Keywords, WORD_LENGTH};
 use std::{
     collections::{HashMap, HashSet},
     fs::File,
@@ -14,7 +14,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::Semaphore;
-use tracing::trace;
+use tracing::{instrument, trace};
 
 #[derive(Parser, Debug)]
 #[clap(verbatim_doc_comment)]
@@ -38,15 +38,9 @@ impl InsertOrDeleteAction {
     /// - There is an error reading the CSV records.
     /// - There is an error converting the CSV records to the expected data
     ///   types.
-    /// - The Findex instance cannot be instantiated.
-    /// - The Findex instance cannot insert or delete the data.
-    /// - The semaphore cannot acquire a permit.
-    async fn insert_or_delete(
-        &self,
-        rest_client: &FindexRestClient,
-        is_insert: bool,
-    ) -> CliResult<Keywords> {
-        let file = File::open(self.csv.clone())?;
+    #[instrument(err)]
+    pub(crate) fn from_csv(p: PathBuf) -> CliResult<KeywordToDataSetsMap> {
+        let file = File::open(p)?;
 
         let bindings = csv::Reader::from_reader(file).byte_records().fold(
             HashMap::new(),
@@ -65,33 +59,38 @@ impl InsertOrDeleteAction {
         );
         trace!("CSV lines are OK");
 
-        // cloning will be eliminated in the future, cf https://github.com/Cosmian/findex-server/issues/28
-        let findex = Arc::<Findex<WORD_LENGTH, Value, String, FindexRestClient>>::new(
-            rest_client.clone().instantiate_findex(
-                self.findex_parameters.index_id,
-                &self.findex_parameters.seed()?,
-            )?,
-        );
+    async fn insert_or_delete(
+        &self,
+        rest_client: FindexRestClient,
+        is_insert: bool,
+    ) -> CliResult<Keywords> {
+        let bindings = Self::from_csv(self.csv.clone())?;
+
+        let findex: Arc<Findex<200, Value, String, FindexRestClient>> =
+            Arc::<Findex<WORD_LENGTH, Value, String, FindexRestClient>>::new(
+                // cheap reference clone
+                rest_client.instantiate_findex(
+                    self.findex_parameters.index_id,
+                    &self.findex_parameters.seed()?,
+                )?,
+            );
         let semaphore = Arc::new(Semaphore::new(MAX_PERMITS));
-        let written_keywords = bindings.keys().cloned().collect::<Vec<_>>();
+        let written_keywords = bindings.keys().collect::<Vec<_>>();
 
         let handles = bindings
+            .clone()
+            .0
             .into_iter()
             .map(|(kw, vs)| {
                 let findex = findex.clone();
                 let semaphore = semaphore.clone();
                 tokio::spawn(async move {
-                    let _permit = semaphore.acquire().await.map_err(|e| {
-                        CliError::Default(format!(
-                            "Acquire error while trying to ask for permit: {e:?}"
-                        ))
-                    })?;
+                    let _permit = semaphore.acquire().await;
                     if is_insert {
-                        findex.insert(kw, vs).await?;
+                        findex.insert(kw, vs).await
                     } else {
-                        findex.delete(kw, vs).await?;
+                        findex.delete(kw, vs).await
                     }
-                    Ok::<_, CliError>(())
                 })
             })
             .collect::<Vec<_>>();
@@ -111,7 +110,7 @@ impl InsertOrDeleteAction {
     ///
     /// # Errors
     /// - If insert new indexes fails
-    pub async fn insert(&self, rest_client: &mut FindexRestClient) -> CliResult<Keywords> {
+    pub async fn insert(&self, rest_client: FindexRestClient) -> CliResult<Keywords> {
         Self::insert_or_delete(self, rest_client, true).await
     }
 
@@ -119,7 +118,7 @@ impl InsertOrDeleteAction {
     ///
     /// # Errors
     /// - If deleting indexes fails
-    pub async fn delete(&self, rest_client: &mut FindexRestClient) -> CliResult<Keywords> {
+    pub async fn delete(&self, rest_client: FindexRestClient) -> CliResult<Keywords> {
         Self::insert_or_delete(self, rest_client, false).await
     }
 }

--- a/crate/cli/src/actions/findex/search.rs
+++ b/crate/cli/src/actions/findex/search.rs
@@ -25,7 +25,7 @@ impl SearchAction {
     ///
     /// Returns an error if the version query fails or if there is an issue
     /// writing to the console.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<SearchResults> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<SearchResults> {
         let findex_instance = rest_client.instantiate_findex(
             self.findex_parameters.index_id,
             &self.findex_parameters.seed()?,
@@ -35,10 +35,10 @@ impl SearchAction {
 
         let mut handles = self
             .keywords
-            .into_iter()
+            .iter()
             .map(|kw| {
                 let semaphore = semaphore.clone();
-                let kw = Keyword::from(kw.into_bytes().as_slice());
+                let kw = Keyword::from(kw.as_ref());
                 let findex_instance = findex_instance.clone();
                 tokio::spawn(async move {
                     let _permit = semaphore.acquire().await.map_err(|e| {

--- a/crate/cli/src/actions/findex/search.rs
+++ b/crate/cli/src/actions/findex/search.rs
@@ -25,7 +25,7 @@ impl SearchAction {
     ///
     /// Returns an error if the version query fails or if there is an issue
     /// writing to the console.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<SearchResults> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<SearchResults> {
         let findex_instance = rest_client.instantiate_findex(
             self.findex_parameters.index_id,
             &self.findex_parameters.seed()?,

--- a/crate/cli/src/actions/findex/search.rs
+++ b/crate/cli/src/actions/findex/search.rs
@@ -38,7 +38,7 @@ impl SearchAction {
             .into_iter()
             .map(|kw| {
                 let semaphore = semaphore.clone();
-                let kw = Keyword::from(kw.into_bytes());
+                let kw = Keyword::from(kw.into_bytes().as_slice());
                 let findex_instance = findex_instance.clone();
                 tokio::spawn(async move {
                     let _permit = semaphore.acquire().await.map_err(|e| {

--- a/crate/cli/src/actions/findex/search.rs
+++ b/crate/cli/src/actions/findex/search.rs
@@ -25,9 +25,13 @@ impl SearchAction {
     ///
     /// Returns an error if the version query fails or if there is an issue
     /// writing to the console.
-    pub async fn run(&self, rest_client: &mut FindexRestClient) -> CliResult<SearchResults> {
-        // cloning will be eliminated in the future, cf https://github.com/Cosmian/findex-server/issues/28
-        let findex_instance = rest_client.clone().instantiate_findex(
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<SearchResults> {
+        let keywords = Keywords::from(self.keyword.clone()).0;
+        if keywords.is_empty() {
+            return Err(CliError::Default("No search results found".to_owned()));
+        }
+
+        let findex_instance = rest_client.instantiate_findex(
             self.findex_parameters.index_id,
             &self.findex_parameters.seed()?,
         )?;

--- a/crate/cli/src/actions/findex/search.rs
+++ b/crate/cli/src/actions/findex/search.rs
@@ -26,11 +26,6 @@ impl SearchAction {
     /// Returns an error if the version query fails or if there is an issue
     /// writing to the console.
     pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<SearchResults> {
-        let keywords = Keywords::from(self.keyword.clone()).0;
-        if keywords.is_empty() {
-            return Err(CliError::Default("No search results found".to_owned()));
-        }
-
         let findex_instance = rest_client.instantiate_findex(
             self.findex_parameters.index_id,
             &self.findex_parameters.seed()?,

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -61,7 +61,7 @@ impl LoginAction {
         config.http_config.access_token = Some(access_token.clone());
 
         info!(
-            "Saving access token in the configuration file {:?}",
+            "Saving access token in the configuration file {:?} ...",
             conf_path
         );
 

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -41,8 +41,17 @@ impl LoginAction {
     ) -> CliResult<String> {
         let login_config = config.http_config.oauth2_conf.as_ref().ok_or_else(|| {
             CliError::Default(format!(
-                "The `login` command (only used for JWT authentication) requires an Identity \
-                 Provider (IdP) that MUST be configured in the oauth2_conf object in {config:?}",
+                "ERROR: Login command requires OAuth2 configuration\n\n\
+                 The `login` command needs an Identity Provider (IdP) configuration in your config file.\n\
+                 Please add an [http_config.oauth2_conf] section to your configuration file at {:?}.\n\n\
+                 Example configuration:\n\n\
+                 [http_config.oauth2_conf]\n\
+                 client_id = \"your-client-id\"\n\
+                 client_secret = \"your-client-secret\"\n\
+                 authorize_url = \"https://your-idp.com/authorize\"\n\
+                 token_url = \"https://your-idp.com/token\"\n\
+                 scopes = [\"openid\", \"email\"]\n",
+                 conf_path.clone().unwrap_or("~/.cosmian/findex.toml".to_owned().into())
             ))
         })?;
 

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -35,7 +35,7 @@ impl LoginAction {
     /// Fails if the configuration file is missing or if the `oauth2_conf` object
     /// Fails if credentials are invalid. No access token could be retrieved.
     pub async fn run(
-        &self,
+        self,
         mut config: FindexClientConfig,
         conf_path: Option<PathBuf>,
     ) -> CliResult<String> {

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -43,15 +43,14 @@ impl LoginAction {
             CliError::Default(format!(
                 "ERROR: Login command requires OAuth2 configuration\n\n\
                  The `login` command needs an Identity Provider (IdP) configuration in your config file.\n\
-                 Please add an [http_config.oauth2_conf] section to your configuration file at {:?}.\n\n\
+                 Please add an [http_config.oauth2_conf] section to your configuration file at {conf_path:?}.\n\n\
                  Example configuration:\n\n\
                  [http_config.oauth2_conf]\n\
                  client_id = \"your-client-id\"\n\
                  client_secret = \"your-client-secret\"\n\
                  authorize_url = \"https://your-idp.com/authorize\"\n\
                  token_url = \"https://your-idp.com/token\"\n\
-                 scopes = [\"openid\", \"email\"]\n",
-                 conf_path.clone().unwrap_or("~/.cosmian/findex.toml".to_owned().into())
+                 scopes = [\"openid\", \"email\"]\n"
             ))
         })?;
 

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use cosmian_findex_client::{reexport::cosmian_http_client::LoginState, FindexClientConfig};
-use tracing::trace;
+use tracing::info;
 
 use crate::error::{result::CliResult, CliError};
 
@@ -61,7 +61,7 @@ impl LoginAction {
         config.http_config.access_token = Some(access_token.clone());
         config.save(conf_path.clone())?;
 
-        trace!(
+        info!(
             "Access token has been saved in the configuration file {:?}",
             conf_path
         );

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -59,12 +59,13 @@ impl LoginAction {
         let access_token = state.finalize().await?;
 
         config.http_config.access_token = Some(access_token.clone());
-        config.save(conf_path.clone())?;
 
         info!(
-            "Access token has been saved in the configuration file {:?}",
+            "Saving access token in the configuration file {:?}",
             conf_path
         );
+
+        config.save(conf_path)?;
 
         Ok(access_token)
     }

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -35,9 +35,9 @@ impl LoginAction {
     /// Fails if the configuration file is missing or if the `oauth2_conf` object
     /// Fails if credentials are invalid. No access token could be retrieved.
     pub async fn run(
-        self,
-        mut config: FindexClientConfig,
-        conf_path: Option<PathBuf>,
+        &self,
+        config: &mut FindexClientConfig,
+        conf_path: &Option<PathBuf>,
     ) -> CliResult<String> {
         let login_config = config.http_config.oauth2_conf.as_ref().ok_or_else(|| {
             CliError::Default(format!(
@@ -64,8 +64,6 @@ impl LoginAction {
             "Saving access token in the configuration file {:?} ...",
             conf_path
         );
-
-        config.save(conf_path)?;
 
         Ok(access_token)
     }

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -1,10 +1,8 @@
-use std::path::PathBuf;
-
+use crate::error::result::CliResult;
 use clap::Parser;
 use cosmian_findex_client::FindexClientConfig;
+use std::path::PathBuf;
 use tracing::info;
-
-use crate::error::result::CliResult;
 
 /// Logout from the Identity Provider.
 ///
@@ -25,6 +23,10 @@ impl LogoutAction {
         conf_path: Option<PathBuf>,
     ) -> CliResult<String> {
         config.http_config.access_token = None;
+        info!(
+            "Deleting access token from the configuration file {:?} ...",
+            conf_path
+        );
         config.save(conf_path)?;
         Ok("\nThe access token was removed from the Findex CLI configuration".to_owned())
     }

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -23,7 +23,7 @@ impl LogoutAction {
     pub fn run(
         &self,
         mut config: FindexClientConfig,
-        conf_path: Option<PathBuf>,
+        conf_path: &Option<PathBuf>,
     ) -> CliResult<String> {
         config.http_config.access_token = None;
         config.save(conf_path.clone())?;

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -21,7 +21,7 @@ impl LogoutAction {
     /// Returns an error if there is an issue loading or saving the
     /// configuration file.
     pub fn run(
-        &self,
+        self,
         mut config: FindexClientConfig,
         conf_path: &Option<PathBuf>,
     ) -> CliResult<String> {

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -1,5 +1,8 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 use cosmian_findex_client::FindexClientConfig;
+use tracing::trace;
 
 use crate::error::result::CliResult;
 
@@ -17,8 +20,19 @@ impl LogoutAction {
     ///
     /// Returns an error if there is an issue loading or saving the
     /// configuration file.
-    pub fn run(&self, conf: &mut FindexClientConfig) -> CliResult<String> {
-        conf.http_config.access_token = None;
+    pub fn run(
+        &self,
+        mut config: FindexClientConfig,
+        conf_path: Option<PathBuf>,
+    ) -> CliResult<String> {
+        config.http_config.access_token = None;
+        config.save(conf_path.clone())?;
+
+        trace!(
+            "Access token has been removed from the configuration file {:?}",
+            conf_path
+        );
+
         Ok("\nThe access token was removed from the Findex CLI configuration".to_owned())
     }
 }

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use cosmian_findex_client::FindexClientConfig;
-use tracing::trace;
+use tracing::info;
 
 use crate::error::result::CliResult;
 
@@ -28,7 +28,7 @@ impl LogoutAction {
         config.http_config.access_token = None;
         config.save(conf_path.clone())?;
 
-        trace!(
+        info!(
             "Access token has been removed from the configuration file {:?}",
             conf_path
         );

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -18,21 +18,14 @@ impl LogoutAction {
     ///
     /// # Errors
     ///
-    /// Returns an error if there is an issue loading or saving the
-    /// configuration file.
+    /// Returns an error if there is an issue saving the configuration file.
     pub fn run(
         self,
         mut config: FindexClientConfig,
-        conf_path: &Option<PathBuf>,
+        conf_path: Option<PathBuf>,
     ) -> CliResult<String> {
         config.http_config.access_token = None;
-        config.save(conf_path.clone())?;
-
-        info!(
-            "Access token has been removed from the configuration file {:?}",
-            conf_path
-        );
-
+        config.save(conf_path)?;
         Ok("\nThe access token was removed from the Findex CLI configuration".to_owned())
     }
 }

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -18,16 +18,15 @@ impl LogoutAction {
     ///
     /// Returns an error if there is an issue saving the configuration file.
     pub fn run(
-        self,
-        mut config: FindexClientConfig,
-        conf_path: Option<PathBuf>,
+        &self,
+        config: &mut FindexClientConfig,
+        conf_path: &Option<PathBuf>,
     ) -> CliResult<String> {
         config.http_config.access_token = None;
         info!(
             "Deleting access token from the configuration file {:?} ...",
             conf_path
         );
-        config.save(conf_path)?;
         Ok("\nThe access token was removed from the Findex CLI configuration".to_owned())
     }
 }

--- a/crate/cli/src/actions/permissions.rs
+++ b/crate/cli/src/actions/permissions.rs
@@ -20,7 +20,7 @@ impl PermissionsAction {
     /// # Errors
     ///
     /// Returns an error if there was a problem running the action.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         match self {
             Self::Create(action) => action
                 .run(rest_client)
@@ -53,7 +53,7 @@ impl CreateIndex {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<Uuid> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<Uuid> {
         let response = rest_client
             .create_index_id()
             .await
@@ -78,7 +78,7 @@ impl ListPermissions {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .list_permission(&self.user)
             .await
@@ -116,7 +116,7 @@ impl SetPermission {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .set_permission(&self.user, &self.permission, &self.index_id)
             .await
@@ -146,7 +146,7 @@ impl RevokePermission {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .revoke_permission(&self.user, &self.index_id)
             .await

--- a/crate/cli/src/actions/permissions.rs
+++ b/crate/cli/src/actions/permissions.rs
@@ -20,7 +20,7 @@ impl PermissionsAction {
     /// # Errors
     ///
     /// Returns an error if there was a problem running the action.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
         match self {
             Self::Create(action) => action
                 .run(rest_client)
@@ -53,7 +53,7 @@ impl CreateIndex {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<Uuid> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<Uuid> {
         let response = rest_client
             .create_index_id()
             .await
@@ -78,7 +78,7 @@ impl ListPermissions {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .list_permission(&self.user)
             .await
@@ -116,7 +116,7 @@ impl SetPermission {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .set_permission(&self.user, &self.permission, &self.index_id)
             .await
@@ -146,7 +146,7 @@ impl RevokePermission {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .revoke_permission(&self.user, &self.index_id)
             .await

--- a/crate/cli/src/actions/permissions.rs
+++ b/crate/cli/src/actions/permissions.rs
@@ -20,7 +20,7 @@ impl PermissionsAction {
     /// # Errors
     ///
     /// Returns an error if there was a problem running the action.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         match self {
             Self::Create(action) => action
                 .run(rest_client)
@@ -53,7 +53,7 @@ impl CreateIndex {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<Uuid> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<Uuid> {
         let response = rest_client
             .create_index_id()
             .await
@@ -78,7 +78,7 @@ impl ListPermissions {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .list_permission(&self.user)
             .await
@@ -116,7 +116,7 @@ impl SetPermission {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .set_permission(&self.user, &self.permission, &self.index_id)
             .await
@@ -146,7 +146,7 @@ impl RevokePermission {
     /// # Errors
     ///
     /// Returns an error if the query execution on the Findex server fails.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let response = rest_client
             .revoke_permission(&self.user, &self.index_id)
             .await

--- a/crate/cli/src/actions/version.rs
+++ b/crate/cli/src/actions/version.rs
@@ -15,7 +15,7 @@ impl ServerVersionAction {
     ///
     /// Returns an error if the version query fails or if there is an issue
     /// writing to the console.
-    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
         let version = rest_client
             .version()
             .await

--- a/crate/cli/src/actions/version.rs
+++ b/crate/cli/src/actions/version.rs
@@ -15,7 +15,7 @@ impl ServerVersionAction {
     ///
     /// Returns an error if the version query fails or if there is an issue
     /// writing to the console.
-    pub async fn run(self, rest_client: FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let version = rest_client
             .version()
             .await

--- a/crate/cli/src/actions/version.rs
+++ b/crate/cli/src/actions/version.rs
@@ -15,7 +15,7 @@ impl ServerVersionAction {
     ///
     /// Returns an error if the version query fails or if there is an issue
     /// writing to the console.
-    pub async fn run(&self, rest_client: &FindexRestClient) -> CliResult<String> {
+    pub async fn run(&self, rest_client: FindexRestClient) -> CliResult<String> {
         let version = rest_client
             .version()
             .await

--- a/crate/cli/src/commands.rs
+++ b/crate/cli/src/commands.rs
@@ -98,7 +98,7 @@ impl CoreFindexActions {
         config: FindexClientConfig,
         conf_path: Option<PathBuf>,
     ) -> CliResult<()> {
-        let action: &CoreFindexActions = self;
+        let action: &Self = self;
         {
             let result = match action {
                 // actions that don't need to return a value and don't edit the configuration
@@ -122,7 +122,7 @@ impl CoreFindexActions {
 
                 // actions that edit the configuration, and don't return a value
                 Self::Login(action) => action.run(config, conf_path).await,
-                Self::Logout(action) => action.run(config, conf_path),
+                Self::Logout(action) => action.run(config, &conf_path),
             };
             match result {
                 Ok(output) => Ok(println!("{output}")),

--- a/crate/cli/src/commands.rs
+++ b/crate/cli/src/commands.rs
@@ -91,7 +91,6 @@ impl CoreFindexActions {
     ///
     /// # Errors
     /// - If the configuration file is not found or invalid
-    #[allow(clippy::unit_arg)] // println! does return () but it prints the output of action.run() beforehand, nothing is "lost" and hence this lint will only cause useless boilerplate code
     pub async fn run(
         self,
         findex_client: FindexRestClient,
@@ -103,14 +102,8 @@ impl CoreFindexActions {
             Self::Datasets(action) => action.run(findex_client).await,
             Self::Permissions(action) => action.run(findex_client).await,
             Self::ServerVersion(action) => action.run(findex_client).await,
-            Self::Delete(action) => {
-                let deleted_keywords = action.delete(findex_client).await?;
-                Ok(format!("Deleted keywords: {deleted_keywords}"))
-            }
-            Self::Insert(action) => {
-                let inserted_keywords = action.insert(findex_client).await?;
-                Ok(format!("Inserted keywords: {inserted_keywords}"))
-            }
+            Self::Delete(action) => action.delete(findex_client).await,
+            Self::Insert(action) => action.insert(findex_client).await,
             Self::Search(action) => {
                 let search_results = action.run(findex_client).await?;
                 Ok(format!("Search results: {search_results}"))
@@ -118,10 +111,13 @@ impl CoreFindexActions {
 
             // actions that edit the configuration
             Self::Login(action) => action.run(config, conf_path).await,
-            Self::Logout(action) => action.run(config, &conf_path),
+            Self::Logout(action) => action.run(config, conf_path),
         };
         match result {
-            Ok(output) => Ok(println!("{output}")),
+            Ok(output) => {
+                println!("{output}");
+                Ok(())
+            }
             Err(e) => Err(e),
         }
     }

--- a/crate/cli/src/commands.rs
+++ b/crate/cli/src/commands.rs
@@ -93,7 +93,7 @@ impl CoreFindexActions {
     /// - If the configuration file is not found or invalid
     #[allow(clippy::unit_arg)] // println! does return () but it prints the output of action.run() beforehand, nothing is "lost" and hence this lint will only cause useless boilerplate code
     pub async fn run(
-        &self,
+        self,
         findex_client: FindexRestClient,
         config: FindexClientConfig,
         conf_path: Option<PathBuf>,

--- a/crate/cli/src/commands.rs
+++ b/crate/cli/src/commands.rs
@@ -83,7 +83,11 @@ pub enum CoreFindexActions {
 
 impl CoreFindexActions {
     /// Process the command line arguments
-    /// TODO(hatem) : update this once fix is working
+    ///
+    /// # Arguments
+    /// * `findex_client` - The Findex client
+    /// * `config` - The Findex client configuration
+    /// * `conf_path` - The path to the configuration file
     ///
     /// # Errors
     /// - If the configuration file is not found or invalid

--- a/crate/cli/src/tests/findex_tests.rs
+++ b/crate/cli/src/tests/findex_tests.rs
@@ -51,7 +51,7 @@ async fn insert_search_delete(
             seed: seed.to_owned(),
             index_id: *index_id,
         },
-        keyword: search_options.keywords.clone(),
+        keywords: search_options.keywords.clone(),
     }
     .run(rest_client.clone())
     .await?;
@@ -77,7 +77,7 @@ async fn insert_search_delete(
             seed: seed.to_owned(),
             index_id: *index_id,
         },
-        keyword: search_options.keywords,
+        keywords: search_options.keywords,
     }
     .run(rest_client)
     .await?;
@@ -226,7 +226,7 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> CliResult<()> {
             seed: TESTS_SEED.to_owned(),
             index_id,
         },
-        keyword: search_options.keywords.clone(),
+        keywords: search_options.keywords.clone(),
     }
     .run(user_rest_client.clone())
     .await?;
@@ -265,7 +265,7 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> CliResult<()> {
             seed: TESTS_SEED.to_owned(),
             index_id,
         },
-        keyword: search_options.keywords.clone(),
+        keywords: search_options.keywords.clone(),
     }
     .run(user_rest_client.clone())
     .await?;
@@ -307,7 +307,7 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> CliResult<()> {
             seed: TESTS_SEED.to_owned(),
             index_id,
         },
-        keyword: search_options.keywords.clone(),
+        keywords: search_options.keywords.clone(),
     }
     .run(user_rest_client)
     .await

--- a/crate/cli/src/tests/permissions.rs
+++ b/crate/cli/src/tests/permissions.rs
@@ -7,19 +7,19 @@ use crate::{
     error::result::CliResult,
 };
 
-pub(crate) async fn create_index_id(rest_client: &FindexRestClient) -> CliResult<Uuid> {
+pub(crate) async fn create_index_id(rest_client: FindexRestClient) -> CliResult<Uuid> {
     CreateIndex.run(rest_client).await
 }
 
 pub(crate) async fn list_permission(
-    rest_client: &FindexRestClient,
+    rest_client: FindexRestClient,
     user: String,
 ) -> CliResult<String> {
     ListPermissions { user }.run(rest_client).await
 }
 
 pub(crate) async fn set_permission(
-    rest_client: &FindexRestClient,
+    rest_client: FindexRestClient,
     user: String,
     index_id: Uuid,
     permission: Permission,
@@ -34,7 +34,7 @@ pub(crate) async fn set_permission(
 }
 
 pub(crate) async fn revoke_permission(
-    rest_client: &FindexRestClient,
+    rest_client: FindexRestClient,
     user: String,
     index_id: Uuid,
 ) -> CliResult<String> {

--- a/crate/client/src/config.rs
+++ b/crate/client/src/config.rs
@@ -78,7 +78,7 @@ impl FindexClientConfig {
                 "Unable to convert the configuration path to a string".to_owned(),
             )
         })?)?;
-        println!("Saving configuration to: {conf_path_buf:?}");
+        println!("Configuration has been saved to: {conf_path_buf:?}");
 
         Ok(())
     }

--- a/crate/client/src/rest_client.rs
+++ b/crate/client/src/rest_client.rs
@@ -34,10 +34,10 @@ impl Display for SuccessResponse {
 #[derive(Clone)]
 pub struct FindexRestClient {
     pub http_client: HttpClient,
-    /// Each instance of FindexRestClient is associated with a specific index
-    /// however, since all RestClient are instantiated with the same http_client,
-    /// we keep the client in the base struct and create each new index_id bounded
-    /// InstantiatedFindex after providing its index_id via the instantiate_findex
+    /// Each instance of `FindexRestClient` is associated with a specific index
+    /// however, since all `RestClient` are instantiated with the same `http_client`,
+    /// we keep the client in the base struct and create each new `index_id` bounded
+    /// `InstantiatedFindex` after providing its `index_id` via the `instantiate_findex`
     /// function.
     index_id: Option<Uuid>,
 }

--- a/crate/client/src/rest_client.rs
+++ b/crate/client/src/rest_client.rs
@@ -34,8 +34,11 @@ impl Display for SuccessResponse {
 #[derive(Clone)]
 pub struct FindexRestClient {
     pub http_client: HttpClient,
-    pub config: FindexClientConfig,
-    // TODO: why is it an option?
+    /// Each instance of FindexRestClient is associated with a specific index
+    /// however, since all RestClients are instantiated with the same http_client,
+    /// we keep the client in the base struct and create each new index_id bounded
+    /// InstantiatedFindex after providing its index_id via the instantiate_findex
+    /// function.
     index_id: Option<Uuid>,
 }
 
@@ -47,7 +50,7 @@ impl FindexRestClient {
     /// # Errors
     /// Return an error if the configuration file is not found or if the
     /// configuration is invalid or if the client cannot be instantiated.
-    pub fn new(config: FindexClientConfig) -> Result<Self, FindexClientError> {
+    pub fn new(config: &FindexClientConfig) -> Result<Self, FindexClientError> {
         // Instantiate a Findex server REST client with the given configuration
         let client = HttpClient::instantiate(&config.http_config).with_context(|| {
             format!(
@@ -58,7 +61,6 @@ impl FindexRestClient {
 
         Ok(Self {
             http_client: client,
-            config,
             index_id: None,
         })
     }
@@ -67,7 +69,6 @@ impl FindexRestClient {
     fn new_with_index_id(self, index_id: Uuid) -> Self {
         Self {
             http_client: self.http_client,
-            config: self.config,
             index_id: Some(index_id),
         }
     }

--- a/crate/client/src/rest_client.rs
+++ b/crate/client/src/rest_client.rs
@@ -35,7 +35,7 @@ impl Display for SuccessResponse {
 pub struct FindexRestClient {
     pub http_client: HttpClient,
     /// Each instance of FindexRestClient is associated with a specific index
-    /// however, since all RestClients are instantiated with the same http_client,
+    /// however, since all RestClient are instantiated with the same http_client,
     /// we keep the client in the base struct and create each new index_id bounded
     /// InstantiatedFindex after providing its index_id via the instantiate_findex
     /// function.

--- a/crate/client/src/rest_client.rs
+++ b/crate/client/src/rest_client.rs
@@ -31,14 +31,16 @@ impl Display for SuccessResponse {
     }
 }
 
+/// A reusable factory for instanciating index-bounded `FindexRestClients`
+/// that interact with a Findex server.s
+///
+/// The base client contains shared HTTP settings but no index association.  
+/// To perform operations on indexes, create an index-specific instance via [`instantiate_findex`]:
 #[derive(Clone)]
 pub struct FindexRestClient {
     pub http_client: HttpClient,
-    /// Each instance of `FindexRestClient` is associated with a specific index
-    /// however, since all `RestClient` are instantiated with the same `http_client`,
-    /// we keep the client in the base struct and create each new `index_id` bounded
-    /// `InstantiatedFindex` after providing its `index_id` via the `instantiate_findex`
-    /// function.
+    /// When instanciating a `FindexRestClient` factory, the `index_id` is not known yet and hence
+    /// set to None. It is set when creating an index-specific instance via [`instantiate_findex`].
     index_id: Option<Uuid>,
 }
 

--- a/crate/structs/src/findex/keywords.rs
+++ b/crate/structs/src/findex/keywords.rs
@@ -13,6 +13,12 @@ impl<'a> From<&'a [u8]> for Keyword {
     }
 }
 
+impl From<Vec<u8>> for Keyword {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
 impl std::fmt::Display for Keyword {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", String::from_utf8_lossy(&self.0))
@@ -43,7 +49,7 @@ impl From<Vec<String>> for Keywords {
     fn from(strings: Vec<String>) -> Self {
         let keywords = strings
             .into_iter()
-            .map(|s| Keyword::from(s.as_ref()))
+            .map(|s| Keyword::from(s.into_bytes()))
             .collect();
         Self(keywords)
     }

--- a/crate/test_server/src/test_server.rs
+++ b/crate/test_server/src/test_server.rs
@@ -118,7 +118,7 @@ pub async fn start_test_server_with_options(
 
     // Create a (object owner) conf
     let (owner_client_conf_path, owner_client_conf) = generate_owner_conf(&server_params)?;
-    let findex_client = FindexRestClient::new(owner_client_conf.clone())?;
+    let findex_client = FindexRestClient::new(&owner_client_conf)?;
 
     info!(
         "Starting Findex test server at URL: {} with server params {:?}",


### PR DESCRIPTION
## Tasks : 
- [x] pass ownership in cli to reduce cloning during findex ops
- [x] actually clone during tests because it's OK
- [x] change the owned values of "PathBuf" type to references whenever possible
- [x] update login error message


The code was setup so that tests use references and the CLI actions, when executed, clone the findex client each single time. It should be the opposite, hence this PR.