### PR TITLE
Feat/reduce cloning v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode
 .env
 cosmian-findex-server/
+.venv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kmip"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#d71edaa6ac3c8c308c050db9882eeef6beda05ec"
 dependencies = [
  "bitflags 2.8.0",
  "chrono",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_access"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#d71edaa6ac3c8c308c050db9882eeef6beda05ec"
 dependencies = [
  "cosmian_kmip",
  "serde",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_cli"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#d71edaa6ac3c8c308c050db9882eeef6beda05ec"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_client"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#d71edaa6ac3c8c308c050db9882eeef6beda05ec"
 dependencies = [
  "cloudproof",
  "cosmian_config_utils",
@@ -1383,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_crypto"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#d71edaa6ac3c8c308c050db9882eeef6beda05ec"
 dependencies = [
  "aes-gcm-siv",
  "argon2",
@@ -2524,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -3123,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64 0.22.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -5303,8 +5303,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "safe_pqc_kyber"
-version = "0.6.3"
-source = "git+https://github.com/bwesterb/argyle-kyber?branch=master#d22c627406d436fa8446a0df48715b0ab78041c4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kmip"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#7688506adf3512b3135c3eb423c2817de01f2e3e"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
 dependencies = [
  "bitflags 2.8.0",
  "chrono",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_access"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#7688506adf3512b3135c3eb423c2817de01f2e3e"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
 dependencies = [
  "cosmian_kmip",
  "serde",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_cli"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#7688506adf3512b3135c3eb423c2817de01f2e3e"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_client"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#7688506adf3512b3135c3eb423c2817de01f2e3e"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
 dependencies = [
  "cloudproof",
  "cosmian_config_utils",
@@ -1383,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_crypto"
 version = "4.22.1"
-source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#7688506adf3512b3135c3eb423c2817de01f2e3e"
+source = "git+https://www.github.com/Cosmian/kms?branch=feat%2Fadd_digest_and_mac_kmip_operations#ebd22790d98c70c8336e2b547c0c578ee5be0112"
 dependencies = [
  "aes-gcm-siv",
  "argon2",
@@ -2716,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchers"
@@ -4676,9 +4676,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f41ffb7cf259f1ecc2876861a17e7142e63ead296f671f81f6ae85903e0d6"
+checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
 dependencies = [
  "getrandom 0.3.1",
  "serde",
@@ -5278,28 +5278,33 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "safe_pqc_kyber"
+version = "0.6.3"
+source = "git+https://github.com/bwesterb/argyle-kyber?branch=master#d22c627406d436fa8446a0df48715b0ab78041c4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,7 @@ url = "2.5"
 uuid = { version = "1.13", features = ["v4", "serde"] }
 x509-parser = "0.17"
 zeroize = { version = "1.8", default-features = false }
+
+[patch.crates-io]
+# TODO: delete this upon covercrypt next release ( > 14.0.O)
+pqc_kyber = { package = "safe_pqc_kyber", git = "https://github.com/bwesterb/argyle-kyber", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,3 @@ url = "2.5"
 uuid = { version = "1.13", features = ["v4", "serde"] }
 x509-parser = "0.17"
 zeroize = { version = "1.8", default-features = false }
-
-[patch.crates-io]
-# TODO: delete this upon covercrypt next release ( > 14.0.O)
-pqc_kyber = { package = "safe_pqc_kyber", git = "https://github.com/bwesterb/argyle-kyber", branch = "master" }

--- a/crate/cli/src/actions/findex/insert_or_delete.rs
+++ b/crate/cli/src/actions/findex/insert_or_delete.rs
@@ -43,7 +43,7 @@ impl InsertOrDeleteAction {
         kms_client: KmsClient,
         is_insert: bool,
     ) -> CliResult<Keywords> {
-        let file = File::open(self.csv.clone())?;
+        let file = File::open(&self.csv)?;
 
         let bindings = csv::Reader::from_reader(file).byte_records().fold(
             HashMap::new(),

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -33,7 +33,7 @@ impl LoginAction {
     /// Fails if credentials are invalid. No access token could be retrieved.
     pub async fn run(&self, config: &mut RestClientConfig) -> CliResult<String> {
         let login_config = config.http_config.oauth2_conf.as_ref().ok_or_else(|| {
-            CliError::Default(format!(
+            CliError::Default(
                 "ERROR: Login command requires OAuth2 configuration\n\n\
                  The `login` command needs an Identity Provider (IdP) configuration in your config file.\n\
                  Please add an [http_config.oauth2_conf] section to your configuration file.\n\n\
@@ -43,8 +43,8 @@ impl LoginAction {
                  client_secret = \"your-client-secret\"\n\
                  authorize_url = \"https://your-idp.com/authorize\"\n\
                  token_url = \"https://your-idp.com/token\"\n\
-                 scopes = [\"openid\", \"email\"]\n"
-            ))
+                 scopes = [\"openid\", \"email\"]\n".to_string()
+        )
         })?;
 
         let state = LoginState::try_from(login_config.clone())?;

--- a/crate/cli/src/actions/login.rs
+++ b/crate/cli/src/actions/login.rs
@@ -43,7 +43,7 @@ impl LoginAction {
                  client_secret = \"your-client-secret\"\n\
                  authorize_url = \"https://your-idp.com/authorize\"\n\
                  token_url = \"https://your-idp.com/token\"\n\
-                 scopes = [\"openid\", \"email\"]\n".to_string()
+                 scopes = [\"openid\", \"email\"]\n".to_owned()
         )
         })?;
 

--- a/crate/cli/src/actions/logout.rs
+++ b/crate/cli/src/actions/logout.rs
@@ -1,7 +1,7 @@
+use crate::error::result::CliResult;
 use clap::Parser;
 use cosmian_findex_client::RestClientConfig;
-
-use crate::error::result::CliResult;
+use tracing::info;
 
 /// Logout from the Identity Provider.
 ///
@@ -17,8 +17,9 @@ impl LogoutAction {
     ///
     /// Returns an error if there is an issue loading or saving the
     /// configuration file.
-    pub fn run(&self, conf: &mut RestClientConfig) -> CliResult<String> {
-        conf.http_config.access_token = None;
+    pub fn run(&self, config: &mut RestClientConfig) -> CliResult<String> {
+        config.http_config.access_token = None;
+        info!("Deleting access token from the configuration file ...",);
         Ok("\nThe access token was removed from the Findex CLI configuration".to_owned())
     }
 }

--- a/crate/cli/src/commands.rs
+++ b/crate/cli/src/commands.rs
@@ -92,7 +92,6 @@ impl CoreFindexActions {
     /// # Arguments
     /// * `findex_client` - The Findex client
     /// * `config` - The Findex client configuration
-    /// * `conf_path` - The path to the configuration file
     ///
     /// # Errors
     /// - If the configuration file is not found or invalid

--- a/crate/cli/src/tests/findex/basic.rs
+++ b/crate/cli/src/tests/findex/basic.rs
@@ -129,7 +129,7 @@ pub(crate) async fn test_findex_no_auth_huge_dataset_local_crypto() -> CliResult
 pub(crate) async fn test_findex_cert_auth() -> CliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server_with_cert_auth().await;
-    let owner_rest_client = RestClient::new(ctx.owner_client_conf.clone())?;
+    let owner_rest_client = RestClient::new(&ctx.owner_client_conf.clone())?;
     let kms_client = instantiate_kms_client()?;
 
     let search_options = SearchOptions {
@@ -142,7 +142,7 @@ pub(crate) async fn test_findex_cert_auth() -> CliResult<()> {
         },
     };
 
-    let index_id = create_index_id(&owner_rest_client).await?;
+    let index_id = create_index_id(owner_rest_client).await?;
     trace!("index_id: {index_id}");
 
     let findex_parameters = FindexParameters::new(index_id, &kms_client, true).await?;
@@ -163,10 +163,10 @@ pub(crate) async fn test_findex_no_auth_searching_with_bad_key() -> CliResult<()
     log_init(None);
     let ctx = start_default_test_findex_server().await;
 
-    let mut rest_client = RestClient::new(ctx.owner_client_conf.clone())?;
+    let mut rest_client = RestClient::new(&ctx.owner_client_conf.clone())?;
     let kms_client = instantiate_kms_client()?;
 
-    let index_id = create_index_id(&rest_client).await?;
+    let index_id = create_index_id(rest_client.clone()).await?;
     trace!("index_id: {index_id}");
 
     // Search 2 entries in a small dataset. Expect 2 results.

--- a/crate/cli/src/tests/findex/utils.rs
+++ b/crate/cli/src/tests/findex/utils.rs
@@ -1,12 +1,3 @@
-use std::{ops::Deref, path::PathBuf};
-
-use cosmian_findex_client::{FindexRestClient, KmsEncryptionLayer, RestClient, RestClientConfig};
-use cosmian_kms_cli::reexport::cosmian_kms_client::{
-    reexport::cosmian_http_client::HttpClientConfig, KmsClient, KmsClientConfig,
-};
-use test_findex_server::start_default_test_findex_server;
-use uuid::Uuid;
-
 use crate::{
     actions::findex::{
         insert_or_delete::InsertOrDeleteAction, parameters::FindexParameters, search::SearchAction,
@@ -14,6 +5,13 @@ use crate::{
     error::result::CliResult,
     tests::search_options::SearchOptions,
 };
+use cosmian_findex_client::{FindexRestClient, KmsEncryptionLayer, RestClient, RestClientConfig};
+use cosmian_kms_cli::reexport::cosmian_kms_client::{
+    reexport::cosmian_http_client::HttpClientConfig, KmsClient, KmsClientConfig,
+};
+use std::{ops::Deref, path::PathBuf};
+use test_findex_server::start_default_test_findex_server;
+use uuid::Uuid;
 
 pub(crate) const SMALL_DATASET: &str = "../../test_data/datasets/smallpop.csv";
 pub(crate) const HUGE_DATASET: &str = "../../test_data/datasets/business-employment.csv";
@@ -25,7 +23,7 @@ pub(crate) async fn insert_search_delete(
     kms_client: KmsClient,
 ) -> CliResult<()> {
     let mut rest_client =
-        RestClient::new(RestClientConfig::load(Some(PathBuf::from(cli_conf_path)))?)?;
+        RestClient::new(&RestClientConfig::load(Some(PathBuf::from(cli_conf_path)))?)?;
 
     // Index the dataset
     InsertOrDeleteAction {
@@ -91,7 +89,7 @@ pub(crate) async fn create_encryption_layer<const WORD_LENGTH: usize>(
         findex_parameters.hmac_key_id.unwrap(),
         findex_parameters.aes_xts_key_id.unwrap(),
         FindexRestClient::<WORD_LENGTH>::new(
-            RestClient::new(ctx.owner_client_conf.clone())?,
+            RestClient::new(&ctx.owner_client_conf.clone())?,
             findex_parameters.index_id,
         ),
     );

--- a/crate/cli/src/tests/permissions.rs
+++ b/crate/cli/src/tests/permissions.rs
@@ -7,16 +7,16 @@ use crate::{
     error::result::CliResult,
 };
 
-pub(crate) async fn create_index_id(rest_client: &RestClient) -> CliResult<Uuid> {
-    CreateIndex.run(rest_client).await
+pub(crate) async fn create_index_id(rest_client: RestClient) -> CliResult<Uuid> {
+    CreateIndex.run(&rest_client).await
 }
 
-pub(crate) async fn list_permissions(rest_client: &RestClient, user: String) -> CliResult<String> {
-    ListPermissions { user }.run(rest_client).await
+pub(crate) async fn list_permissions(rest_client: RestClient, user: String) -> CliResult<String> {
+    ListPermissions { user }.run(&rest_client).await
 }
 
 pub(crate) async fn set_permission(
-    rest_client: &RestClient,
+    rest_client: RestClient,
     user: String,
     index_id: Uuid,
     permission: Permission,
@@ -26,14 +26,14 @@ pub(crate) async fn set_permission(
         index_id,
         permission,
     }
-    .run(rest_client)
+    .run(&rest_client)
     .await
 }
 
 pub(crate) async fn revoke_permission(
-    rest_client: &RestClient,
+    rest_client: RestClient,
     user: String,
     index_id: Uuid,
 ) -> CliResult<String> {
-    RevokePermission { user, index_id }.run(rest_client).await
+    RevokePermission { user, index_id }.run(&rest_client).await
 }

--- a/crate/client/src/config.rs
+++ b/crate/client/src/config.rs
@@ -76,7 +76,7 @@ impl RestClientConfig {
         self.to_toml(conf_path_buf.to_str().ok_or_else(|| {
             ClientError::Default("Unable to convert the configuration path to a string".to_owned())
         })?)?;
-        println!("Saving configuration to: {conf_path_buf:?}");
+        println!("Configuration has been saved to: {conf_path_buf:?}");
 
         Ok(())
     }

--- a/crate/client/src/config.rs
+++ b/crate/client/src/config.rs
@@ -33,7 +33,7 @@ impl RestClientConfig {
     /// Load the configuration from the given path
     ///
     /// # Arguments
-    /// * `conf_path` - The path to the configuration file
+    /// * `conf` - The path to the configuration file
     ///
     /// # Errors
     /// Return an error if the configuration file is not found or if the

--- a/crate/client/src/rest_client.rs
+++ b/crate/client/src/rest_client.rs
@@ -28,7 +28,6 @@ impl Display for SuccessResponse {
 #[derive(Clone)]
 pub struct RestClient {
     pub http_client: HttpClient,
-    pub config: RestClientConfig,
 }
 
 impl RestClient {
@@ -39,7 +38,7 @@ impl RestClient {
     /// # Errors
     /// Return an error if the configuration file is not found or if the
     /// configuration is invalid or if the client cannot be instantiated.
-    pub fn new(config: RestClientConfig) -> Result<Self, ClientError> {
+    pub fn new(config: &RestClientConfig) -> Result<Self, ClientError> {
         // Instantiate a Findex server REST client with the given configuration
         let client = HttpClient::instantiate(&config.http_config).with_context(|| {
             format!(
@@ -50,7 +49,6 @@ impl RestClient {
 
         Ok(Self {
             http_client: client,
-            config,
         })
     }
 

--- a/crate/structs/src/findex/keywords.rs
+++ b/crate/structs/src/findex/keywords.rs
@@ -13,6 +13,12 @@ impl<'a> From<&'a [u8]> for Keyword {
     }
 }
 
+impl From<Vec<u8>> for Keyword {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
 impl std::fmt::Display for Keyword {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", String::from_utf8_lossy(&self.0))
@@ -62,7 +68,7 @@ impl From<Vec<String>> for Keywords {
     fn from(strings: Vec<String>) -> Self {
         let keywords = strings
             .into_iter()
-            .map(|s| Keyword::from(s.as_ref()))
+            .map(|s| Keyword::from(s.into_bytes()))
             .collect();
         Self(keywords)
     }

--- a/crate/test_server/src/test_server.rs
+++ b/crate/test_server/src/test_server.rs
@@ -118,7 +118,7 @@ pub async fn start_test_server_with_options(
 
     // Create a (object owner) conf
     let (owner_client_conf_path, owner_client_conf) = generate_owner_conf(&server_params)?;
-    let rest_client = RestClient::new(owner_client_conf.clone())?;
+    let findex_client = RestClient::new(&owner_client_conf)?;
 
     info!(
         "Starting Findex test server at URL: {} with server params {:?}",
@@ -128,7 +128,7 @@ pub async fn start_test_server_with_options(
     let (server_handle, thread_handle) = start_test_findex_server(server_params);
 
     // wait for the server to be up
-    wait_for_server_to_start(&rest_client)
+    wait_for_server_to_start(&findex_client)
         .await
         .expect("server timeout");
 


### PR DESCRIPTION
( legacy description, for reference only )

pass ownership in cli to reduce cloning during findex ops
actually clone during tests because it's OK
change the owned values of "PathBuf" type to references whenever possible
update login error message

The code was setup so that tests use references and the CLI actions, when executed, clone the findex client each single time. It should be the opposite, hence this PR.