### PR TITLE
ci: remove Ubuntu 20.04 support according to Github

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -27,9 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distribution: ubuntu-20.04
-            archive-name: ubuntu_20_04
-            target: x86_64-unknown-linux-gnu
           - distribution: ubuntu-22.04
             archive-name: ubuntu_22_04
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/main_base.yml
+++ b/.github/workflows/main_base.yml
@@ -100,7 +100,7 @@ jobs:
             cosmian@package.cosmian.com:$DESTINATION_DIR/
 
           if [ "${{ inputs.debug_or_release }}" = "release" ]; then
-            ssh -o 'StrictHostKeyChecking no' -i /root/.ssh/id_rsa cosmian@package.cosmian.com mkdir -p $DESTINATION_DIR/{rhel9,ubuntu-20.04,ubuntu-22.04,ubuntu-24.04}
+            ssh -o 'StrictHostKeyChecking no' -i /root/.ssh/id_rsa cosmian@package.cosmian.com mkdir -p $DESTINATION_DIR/{rhel9,ubuntu-22.04,ubuntu-24.04}
 
             # RedHat 9 package
             scp -o 'StrictHostKeyChecking no' \
@@ -108,9 +108,6 @@ jobs:
               cosmian@package.cosmian.com:$DESTINATION_DIR/rhel9
 
             # Ubuntu packages
-            scp -o 'StrictHostKeyChecking no' \
-              -i /root/.ssh/id_rsa ubuntu_20_04-${{ inputs.debug_or_release }}/debian/*.deb \
-              cosmian@package.cosmian.com:$DESTINATION_DIR/ubuntu-20.04
             scp -o 'StrictHostKeyChecking no' \
               -i /root/.ssh/id_rsa ubuntu_22_04-${{ inputs.debug_or_release }}/debian/*.deb \
               cosmian@package.cosmian.com:$DESTINATION_DIR/ubuntu-22.04
@@ -126,7 +123,6 @@ jobs:
           files: |
             *.zip
             rhel9-release/generate-rpm/*.rpm \
-            ubuntu_20_04-release/debian/*.deb \
             ubuntu_22_04-release/debian/*.deb \
             ubuntu_24_04-release/debian/*.deb
 


### PR DESCRIPTION
According to Github: https://github.com/actions/runner-images/issues/11101 (April 2025)
According to Ubuntu: https://ubuntu.com/about/release-cycle (May 2025)