### PR TITLE
chore: bump Findex to 7.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,5 +9,5 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/main_base.yml
     with:
-      toolchain: nightly-2025-01-01
+      toolchain: nightly-2025-03-31
       debug_or_release: debug

--- a/.github/workflows/main_release.yml
+++ b/.github/workflows/main_release.yml
@@ -16,5 +16,5 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/main_base.yml
     with:
-      toolchain: nightly-2025-01-01
+      toolchain: nightly-2025-03-31
       debug_or_release: release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
  "cosmian_config_utils",
  "cosmian_cover_crypt",
  "cosmian_crypto_core 10.1.0",
- "cosmian_findex 7.0.0",
+ "cosmian_findex 7.1.0",
  "cosmian_findex_client",
  "cosmian_findex_structs",
  "cosmian_kms_client",
@@ -1240,11 +1240,16 @@ dependencies = [
 
 [[package]]
 name = "cosmian_findex"
-version = "7.0.0"
-source = "git+https://github.com/Cosmian/findex?rev=6329b6b2f2b64b033e40b05cd12ca1c9b5ee376f#6329b6b2f2b64b033e40b05cd12ca1c9b5ee376f"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc2ce562374fb7bd202a123bce41f26328895901d8161923fa62c41dd551235"
 dependencies = [
  "aes",
  "cosmian_crypto_core 10.1.0",
+ "criterion",
+ "futures",
+ "rand 0.9.0",
+ "rand_distr",
  "redis 0.28.2",
  "tokio",
  "xts-mode",
@@ -1256,7 +1261,7 @@ version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "cosmian_crypto_core 10.1.0",
- "cosmian_findex 7.0.0",
+ "cosmian_findex 7.1.0",
  "cosmian_findex_structs",
  "cosmian_http_client",
  "cosmian_kms_client",
@@ -1284,7 +1289,7 @@ dependencies = [
  "chrono",
  "clap",
  "cosmian_crypto_core 10.1.0",
- "cosmian_findex 7.0.0",
+ "cosmian_findex 7.1.0",
  "cosmian_findex_structs",
  "cosmian_logger",
  "dotenvy",
@@ -1310,7 +1315,7 @@ version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "cosmian_crypto_core 10.1.0",
- "cosmian_findex 7.0.0",
+ "cosmian_findex 7.1.0",
  "thiserror 2.0.12",
  "tracing",
  "uuid",
@@ -1339,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kmip"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "bitflags 2.9.0",
  "chrono",
@@ -1360,7 +1365,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_access"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "cosmian_kmip",
  "serde",
@@ -1369,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_base_hsm"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "async-trait",
  "cosmian_kms_interfaces",
@@ -1421,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_crypto"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "aes-gcm-siv",
  "argon2",
@@ -1445,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_interfaces"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "async-trait",
  "cosmian_kmip",
@@ -1459,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_server"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -1518,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "cosmian_kms_server_database"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "async-trait",
  "clap",
@@ -1606,6 +1611,8 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
+ "plotters",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -1623,6 +1630,25 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3782,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "pkcs11_sys"
 version = "0.2.17"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 
 [[package]]
 name = "pkcs5"
@@ -3816,6 +3842,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "poly1305"
@@ -3929,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "proteccio_pkcs11_loader"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "cosmian_kms_base_hsm",
  "cosmian_kms_interfaces",
@@ -4069,10 +4123,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.0",
+]
+
+[[package]]
 name = "rawsql"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70b36c8415361d34d90adf494f45bc18e568f909b5946d27c79559ddd812fa8"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redis"
@@ -5708,7 +5792,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "utimaco_pkcs11_loader"
 version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=develop#190c0a2b840d62654925232c5cdf4cf6f7819a49"
+source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
 dependencies = [
  "cosmian_kms_base_hsm",
  "cosmian_kms_interfaces",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -579,25 +579,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "axum"
-version = "0.6.20"
+name = "aws-lc-rs"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "itoa",
  "matchit",
  "memchr",
@@ -606,25 +634,28 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -688,6 +719,29 @@ name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "binstring"
@@ -834,6 +888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +986,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,7 +1022,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -975,6 +1049,15 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1104,7 +1187,7 @@ dependencies = [
  "cosmian_findex_structs",
  "cosmian_kms_client",
  "cosmian_kms_crypto",
- "cosmian_logger",
+ "cosmian_logger 0.2.0",
  "csv",
  "der",
  "hex",
@@ -1135,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "cosmian_config_utils"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d173d00549fed16e64077526ff6ed2d2abbacd748ca57815734e0e6b74f8a3"
+checksum = "56b96586a73d420cdd4cee41e2a9f69f33c28ae5576cb429db329ffee9398662"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -1265,7 +1348,7 @@ dependencies = [
  "cosmian_findex_structs",
  "cosmian_http_client",
  "cosmian_kms_client",
- "cosmian_logger",
+ "cosmian_logger 0.2.0",
  "reqwest 0.11.27",
  "serde",
  "test_kms_server",
@@ -1291,7 +1374,7 @@ dependencies = [
  "cosmian_crypto_core 10.1.0",
  "cosmian_findex 7.1.0",
  "cosmian_findex_structs",
- "cosmian_logger",
+ "cosmian_logger 0.2.0",
  "dotenvy",
  "futures",
  "openssl",
@@ -1323,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "cosmian_http_client"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f76ac31d536d790fded13033cd27725ac3cbd382662659671131b13810bdf3"
+checksum = "5a5325632d5fa3093c110bdcddb284b6df6e60b321ea7444d663e27a42459e2e"
 dependencies = [
  "actix-web",
  "derive_more 0.99.19",
@@ -1343,13 +1426,14 @@ dependencies = [
 
 [[package]]
 name = "cosmian_kmip"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f31d793a09e6b0ecc7d921150d489366c26d80f2a5ceb0202ff2c9276622b1"
 dependencies = [
  "bitflags 2.9.0",
- "chrono",
- "cosmian_logger",
+ "cosmian_logger 0.1.1",
  "hex",
+ "kmip-derive",
  "leb128",
  "num-bigint-dig",
  "serde",
@@ -1364,8 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "cosmian_kms_access"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246f79db0e5808f1f4bc0c7520e10e8d1039bb01533778c3dcbe7fe6b450017f"
 dependencies = [
  "cosmian_kmip",
  "serde",
@@ -1373,14 +1458,15 @@ dependencies = [
 
 [[package]]
 name = "cosmian_kms_base_hsm"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10d29462b2672fb73bb3fef4549d773d7403cafac1a40c0e37a34b02bd74fc6"
 dependencies = [
  "async-trait",
  "cosmian_kms_interfaces",
+ "cosmian_pkcs11_sys",
  "libloading",
  "lru",
- "pkcs11_sys",
  "rand 0.9.0",
  "thiserror 2.0.12",
  "tracing",
@@ -1425,8 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "cosmian_kms_crypto"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df22427cc548304b81465bb720b951f0995da47353126eb53c9fb96c8466dbac"
 dependencies = [
  "aes-gcm-siv",
  "argon2",
@@ -1434,7 +1521,7 @@ dependencies = [
  "cosmian_cover_crypt",
  "cosmian_crypto_core 10.1.0",
  "cosmian_kmip",
- "cosmian_logger",
+ "cosmian_logger 0.2.0",
  "hex",
  "num-bigint-dig",
  "openssl",
@@ -1443,18 +1530,21 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tracing",
+ "uuid",
  "x509-parser",
  "zeroize",
 ]
 
 [[package]]
 name = "cosmian_kms_interfaces"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c82f652d92d41bdee121a508a11bfd01e6ef1f1594a526ba19ab86719cbcd9"
 dependencies = [
  "async-trait",
  "cosmian_kmip",
  "num-bigint-dig",
+ "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tracing",
@@ -1463,8 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "cosmian_kms_server"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b76b219ea368cf669b4a6f2ec51d26e44d49faf1a6f9a400f80e2318bfad7f1"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -1488,21 +1579,18 @@ dependencies = [
  "cosmian_kms_crypto",
  "cosmian_kms_interfaces",
  "cosmian_kms_server_database",
+ "cosmian_logger 0.2.0",
  "dotenvy",
  "futures",
  "hex",
- "lazy_static",
  "log",
  "num-bigint-dig",
  "oauth2 5.0.0",
  "openidconnect",
  "openssl",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
  "proteccio_pkcs11_loader",
  "reqwest 0.11.27",
+ "rustls 0.23.25",
  "serde",
  "serde_json",
  "strum",
@@ -1511,8 +1599,6 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
  "url",
  "utimaco_pkcs11_loader",
  "uuid",
@@ -1522,19 +1608,19 @@ dependencies = [
 
 [[package]]
 name = "cosmian_kms_server_database"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93a1dad2a73c74bf6d73638868648308eb2576cc84bd94fb2274b6922e01293"
 dependencies = [
  "async-trait",
- "clap",
  "cloudproof_findex",
  "cosmian_crypto_core 10.1.0",
  "cosmian_kmip",
  "cosmian_kms_crypto",
  "cosmian_kms_interfaces",
  "hex",
- "lazy_static",
  "lru",
+ "num-bigint-dig",
  "num_cpus",
  "rawsql",
  "redis 0.23.3",
@@ -1542,7 +1628,6 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror 2.0.12",
- "tiny-keccak",
  "tokio",
  "tracing",
  "url",
@@ -1560,6 +1645,33 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "cosmian_logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabbc045f06d6b223dd21a5b6368baf301d341501f9cd36074918fd73126d92c"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "syslog-tracing",
+ "thiserror 2.0.12",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "cosmian_pkcs11_sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5887bc331eba06478add7025fbc0ed12f6b89e0ad4d67dd3638ac7778a43d"
 
 [[package]]
 name = "cpufeatures"
@@ -1974,6 +2086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2525,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
+ "indexmap 2.8.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,12 +2584,6 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.2",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2619,7 +2756,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2642,9 +2779,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2686,14 +2825,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 0.14.32",
+ "hyper 1.6.0",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
@@ -3046,6 +3186,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kmip-derive"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f09fc18967a62572fdaf82f2577cd4440d1e337cff30d8b01c846fe00e12f85"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3209,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128"
@@ -3098,6 +3254,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3535,41 +3697,57 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.23.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest 0.12.15",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.16.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
- "async-trait",
  "futures-core",
- "http 0.2.12",
+ "http 1.3.1",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.69",
+ "reqwest 0.12.15",
+ "thiserror 2.0.12",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.6.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3579,30 +3757,40 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.15.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1869fb4bb9b35c5ba8a1e40c9b128a7b4c010d07091e864a29da19e4fe2ca4d7"
+checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e27d446dabd68610ef0b77d07b102ecde827a4596ea9c01a4d3811e945b286"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.23.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "lazy_static",
- "once_cell",
  "opentelemetry",
- "ordered-float 4.6.0",
  "percent-encoding",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "rand 0.9.0",
+ "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3610,15 +3798,6 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
@@ -3806,11 +3985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs11_sys"
-version = "0.2.17"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
-
-[[package]]
 name = "pkcs5"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3940,6 +4114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3959,9 +4143,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3969,9 +4153,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3982,13 +4166,14 @@ dependencies = [
 
 [[package]]
 name = "proteccio_pkcs11_loader"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3b270a4fc9051507a0a59c92c05f70b7d2bf8cd2d33329f41c9cd025bf830f"
 dependencies = [
  "cosmian_kms_base_hsm",
  "cosmian_kms_interfaces",
+ "cosmian_pkcs11_sys",
  "libloading",
- "pkcs11_sys",
  "tracing",
  "uuid",
 ]
@@ -4004,7 +4189,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls 0.23.25",
  "socket2 0.5.8",
  "thiserror 2.0.12",
@@ -4023,7 +4208,7 @@ dependencies = [
  "getrandom 0.3.2",
  "rand 0.9.0",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls 0.23.25",
  "rustls-pki-types",
  "slab",
@@ -4277,7 +4462,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -4318,6 +4503,7 @@ checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.3.1",
@@ -4417,6 +4603,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4441,6 +4633,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
@@ -4448,7 +4653,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -4470,6 +4675,7 @@ version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4521,6 +4727,7 @@ version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4650,7 +4857,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.1",
+ "ordered-float",
  "serde",
 ]
 
@@ -4947,7 +5154,7 @@ checksum = "882ceaa29cade31beca7129b6beeb05737f44f82dbe2a9806ecea5a7093d00b7"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.5.0",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -5093,20 +5300,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5170,6 +5377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syslog-tracing"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d349bc2df408b4bf656709a29643641cef7f1795d708f88b105c626a8f64f6e4"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,7 +5417,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -5216,7 +5434,7 @@ dependencies = [
  "actix-server",
  "cosmian_findex_client",
  "cosmian_findex_server",
- "cosmian_logger",
+ "cosmian_logger 0.2.0",
  "criterion",
  "tokio",
  "tracing",
@@ -5228,11 +5446,9 @@ name = "test_kms_server"
 version = "0.3.0"
 dependencies = [
  "actix-server",
- "base64 0.22.1",
  "cosmian_cli",
  "cosmian_kms_server",
- "cosmian_kms_server_database",
- "cosmian_logger",
+ "cosmian_logger 0.2.0",
  "criterion",
  "serde_json",
  "tempfile",
@@ -5408,16 +5624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5540,23 +5746,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "h2 0.4.10",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
+ "socket2 0.5.8",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -5658,9 +5867,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.24.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -5791,13 +6000,14 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utimaco_pkcs11_loader"
-version = "4.24.0"
-source = "git+https://www.github.com/Cosmian/kms?branch=findex_7_1#fed06382584743dbbee0b6b4e9e5dd7a3341d769"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ad933f257540e2cb2185f54e5bddf8dccc99aaf56363ced7e86c515387f429"
 dependencies = [
  "cosmian_kms_base_hsm",
  "cosmian_kms_interfaces",
+ "cosmian_pkcs11_sys",
  "libloading",
- "pkcs11_sys",
  "tracing",
  "uuid",
 ]
@@ -6023,6 +6233,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,19 +48,17 @@ cosmian_config_utils = "0.1.1"
 cosmian_cover_crypt = "15.0"
 cosmian_cli = { path = "cli/crate/cli" }
 cosmian_crypto_core = { version = "10.1.0", default-features = false }
-cosmian_findex = { git = "https://github.com/Cosmian/findex", features = [
-  "redis-mem",
-], rev = "6329b6b2f2b64b033e40b05cd12ca1c9b5ee376f" }
+cosmian_findex = { version = "7.1.0", features = ["redis-mem"] }
 cosmian_findex_client = { path = "cli/crate/findex_client" }
 cosmian_findex_server = { path = "crate/server" }
 cosmian_findex_structs = { path = "crate/structs" }
 cosmian_http_client = "0.1.1"
 cosmian_kms_client = { path = "cli/crate/kms_client" }
-cosmian_kms_access = { git = "https://www.github.com/Cosmian/kms", branch = "develop" }
-cosmian_kms_crypto = { git = "https://www.github.com/Cosmian/kms", branch = "develop" }
-cosmian_kms_server = { git = "https://www.github.com/Cosmian/kms", branch = "develop" }
-cosmian_kms_server_database = { git = "https://www.github.com/Cosmian/kms", branch = "develop" }
-cosmian_kmip = { git = "https://www.github.com/Cosmian/kms", branch = "develop" }
+cosmian_kms_access = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
+cosmian_kms_crypto = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
+cosmian_kms_server = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
+cosmian_kms_server_database = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
+cosmian_kmip = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
 cosmian_logger = "0.1.1"
 der = { version = "0.7", default-features = false }
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,22 +44,32 @@ actix-server = { version = "2.5", default-features = false }
 actix-web = { version = "4.9", default-features = false }
 base64 = "0.22"
 clap = { version = "4.5", default-features = false }
-cosmian_config_utils = "0.1.1"
+cosmian_config_utils = "0.2"
 cosmian_cover_crypt = "15.0"
-cosmian_cli = { path = "cli/crate/cli" }
-cosmian_crypto_core = { version = "10.1.0", default-features = false }
-cosmian_findex = { version = "7.1.0", features = ["redis-mem"] }
-cosmian_findex_client = { path = "cli/crate/findex_client" }
+cosmian_crypto_core = { version = "10.1", default-features = false }
+cosmian_findex = { version = "7.1", features = ["redis-mem"] }
+cosmian_http_client = "0.2"
+
+### Local crates have been also declared here to simplify publishing - centralizing the versions
 cosmian_findex_server = { path = "crate/server" }
 cosmian_findex_structs = { path = "crate/structs" }
-cosmian_http_client = "0.1.1"
+
+# Client crates
+cosmian_findex_client = { path = "cli/crate/findex_client" }
+cosmian_kms_client_utils = { path = "cli/crate/client_utils" }
 cosmian_kms_client = { path = "cli/crate/kms_client" }
-cosmian_kms_access = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
-cosmian_kms_crypto = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
-cosmian_kms_server = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
-cosmian_kms_server_database = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
-cosmian_kmip = { git = "https://www.github.com/Cosmian/kms", branch = "findex_7_1" }
-cosmian_logger = "0.1.1"
+cosmian_cli = { path = "cli/crate/cli" }
+test_findex_server = { path = "cli/crate/test_findex_server" }
+test_kms_server = { path = "cli/crate/test_kms_server" }
+
+# KMS crates
+cosmian_kms_access = "5.0"
+cosmian_kms_crypto = "5.0"
+cosmian_kms_server = "5.0"
+cosmian_kms_server_database = "5.0"
+cosmian_kmip = "5.0"
+
+cosmian_logger = "0.2"
 der = { version = "0.7", default-features = false }
 hex = "0.4"
 leb128 = "0.2"
@@ -69,7 +79,7 @@ pem = "3.0"
 reqwest = { version = "0.11", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
-strum = { version = "0.25", default-features = false }
+strum = { version = "0.27", default-features = false }
 tempfile = "3.17"
 thiserror = "2.0"
 tokio = { version = "1.43", default-features = false }

--- a/crate/server/Cargo.toml
+++ b/crate/server/Cargo.toml
@@ -44,7 +44,7 @@ clap = { workspace = true, features = [
 ] }
 cosmian_crypto_core = { workspace = true }
 cosmian_findex = { workspace = true }
-cosmian_findex_structs = { path = "../structs" }
+cosmian_findex_structs = { workspace = true }
 cosmian_logger = { workspace = true }
 dotenvy = "0.15"
 futures = "0.3"

--- a/crate/server/src/middlewares/jwt.rs
+++ b/crate/server/src/middlewares/jwt.rs
@@ -85,9 +85,7 @@ impl JwtConfig {
             alcoholic_jwt::Validation::NotExpired,
         ];
         if let Some(jwt_audience) = &self.jwt_audience {
-            validations.push(alcoholic_jwt::Validation::Audience(
-                jwt_audience.to_string(),
-            ));
+            validations.push(alcoholic_jwt::Validation::Audience(jwt_audience.clone()));
         }
 
         // If a JWKS contains multiple keys, the correct KID first

--- a/crate/structs/Cargo.toml
+++ b/crate/structs/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+description = "Cosmian Findex server structs"
 
 [lib]
 # doc test linking as a separate binary is extremely slow

--- a/deny.toml
+++ b/deny.toml
@@ -104,6 +104,7 @@ allow = [
   "CC0-1.0",
   "MPL-2.0",
   "Unicode-3.0",
+  "OpenSSL",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-01-01"
+channel = "nightly-2025-03-31"
 components = ["rustfmt"]


### PR DESCRIPTION
Small PR to clean develop branch:
- reuse last KMS published crates
- align Rust toolchain version
- clean Cargo.toml