### PR TITLE
fix: guarded write concurrent test

### DIFF
--- a/.github/scripts/cargo_build.ps1
+++ b/.github/scripts/cargo_build.ps1
@@ -16,7 +16,7 @@ function BuildProject {
     Get-ChildItem -Recurse $env:OPENSSL_DIR
 
     # Build `server`
-    $env:RUST_LOG = "cosmian_findex_cli=trace,cosmian_findex_server=trace,test_findex_server=trace"
+    $env:RUST_LOG = "cosmian_findex_cli=error,cosmian_findex_server=error,test_findex_server=error"
     $env:FINDEX_TEST_DB = "sqlite-findex"
     if ($BuildType -eq "release") {
         cargo build -p cosmian_findex_server -p cosmian_findex_cli --release --target x86_64-pc-windows-msvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Semaphore for CLI parallelism ([#46](https://github.com/Cosmian/findex-server/pull/46))
 - Parallelism for write only ([#50](https://github.com/Cosmian/findex-server/pull/50))
 - Delegate encryption to KMS writing a custom encryption layer ([#47](https://github.com/Cosmian/findex-server/pull/47))
-- Move all CLI relative crates on <https://github.com/Cosmian/client> ([#59](https://github.com/Cosmian/findex-server/pull/59))
+- Move all CLI relative crates on <https://github.com/Cosmian/cli> ([#59](https://github.com/Cosmian/findex-server/pull/59))
 
 ### 🐛 Bug Fixes
 

--- a/crate/cli/src/actions/findex_server/tests/datasets.rs
+++ b/crate/cli/src/actions/findex_server/tests/datasets.rs
@@ -58,7 +58,6 @@ async fn dataset_get_entries(
 pub(crate) async fn test_datasets() -> FindexCliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server().await;
-    let owner_rest_client = RestClient::new(ctx.owner_client_conf.clone())?;
 
     let index_id = Uuid::new_v4();
 
@@ -75,27 +74,22 @@ pub(crate) async fn test_datasets() -> FindexCliResult<()> {
     let uuids: Vec<Uuid> = encrypted_entries.iter().map(|(uuid, _)| *uuid).collect();
 
     // Add entries to the dataset
-    dataset_add_entries(
-        owner_rest_client.clone(),
-        &index_id,
-        encrypted_entries.clone(),
-    )
-    .await?;
+    dataset_add_entries(ctx.get_owner_client(), &index_id, encrypted_entries.clone()).await?;
 
     // Get the added entries from the dataset
     let added_entries =
-        dataset_get_entries(owner_rest_client.clone(), &index_id, uuids.clone()).await?;
+        dataset_get_entries(ctx.get_owner_client(), &index_id, uuids.clone()).await?;
     assert_eq!(added_entries.len(), entries_number);
 
     dataset_delete_entries(
-        owner_rest_client.clone(),
+        ctx.get_owner_client(),
         &index_id,
         added_entries.get_uuids().deref().to_owned(),
     )
     .await?;
 
     // Get the added entries from the dataset
-    let deleted_entries = dataset_get_entries(owner_rest_client, &index_id, uuids).await?;
+    let deleted_entries = dataset_get_entries(ctx.get_owner_client(), &index_id, uuids).await?;
     assert_eq!(deleted_entries.len(), 0);
 
     Ok(())

--- a/crate/cli/src/actions/findex_server/tests/findex/basic.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/basic.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use cosmian_findex::{gen_seed, test_single_write_and_read, test_wrong_guard};
+use cosmian_findex::{
+    gen_seed, test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
+};
 use cosmian_findex_structs::{CUSTOM_WORD_LENGTH, Value};
 use cosmian_kms_cli::reexport::test_kms_server::start_default_test_kms_server;
 use cosmian_logger::log_init;
@@ -262,14 +264,13 @@ async fn test_findex_sequential_wrong_guard() -> FindexCliResult<()> {
     Ok(())
 }
 
-// #[ignore = "stack overflow"]
-// #[tokio::test]
-// async fn test_findex_concurrent_read_write() -> CosmianResult<()> {
-//     test_guarded_write_concurrent(
-//         &create_encryption_layer::<CUSTOM_WORD_LENGTH>().await?,
-//         gen_seed(),
-//         Some(100),
-//     )
-//     .await;
-//     Ok(())
-// }
+#[tokio::test]
+async fn test_findex_concurrent_read_write() -> FindexCliResult<()> {
+    test_guarded_write_concurrent(
+        &create_encryption_layer::<CUSTOM_WORD_LENGTH>().await?,
+        gen_seed(),
+        Some(100),
+    )
+    .await;
+    Ok(())
+}

--- a/crate/cli/src/actions/findex_server/tests/findex/basic.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/basic.rs
@@ -264,12 +264,13 @@ async fn test_findex_sequential_wrong_guard() -> FindexCliResult<()> {
     Ok(())
 }
 
+#[cfg(not(target_os = "windows"))]
 #[tokio::test]
 async fn test_findex_concurrent_read_write() -> FindexCliResult<()> {
     test_guarded_write_concurrent(
         &create_encryption_layer::<CUSTOM_WORD_LENGTH>().await?,
         gen_seed(),
-        Some(50),
+        Some(100),
     )
     .await;
     Ok(())

--- a/crate/cli/src/actions/findex_server/tests/findex/basic.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/basic.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use cosmian_findex::{
-    gen_seed, test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
-};
+#[cfg(not(target_os = "windows"))]
+use cosmian_findex::test_guarded_write_concurrent;
+use cosmian_findex::{gen_seed, test_single_write_and_read, test_wrong_guard};
 use cosmian_findex_structs::{CUSTOM_WORD_LENGTH, Value};
 use cosmian_kms_cli::reexport::test_kms_server::start_default_test_kms_server;
 use cosmian_logger::log_init;
@@ -270,7 +270,7 @@ async fn test_findex_concurrent_read_write() -> FindexCliResult<()> {
     test_guarded_write_concurrent(
         &create_encryption_layer::<CUSTOM_WORD_LENGTH>().await?,
         gen_seed(),
-        Some(100),
+        Some(20),
     )
     .await;
     Ok(())

--- a/crate/cli/src/actions/findex_server/tests/findex/basic.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/basic.rs
@@ -269,7 +269,7 @@ async fn test_findex_concurrent_read_write() -> FindexCliResult<()> {
     test_guarded_write_concurrent(
         &create_encryption_layer::<CUSTOM_WORD_LENGTH>().await?,
         gen_seed(),
-        Some(100),
+        Some(50),
     )
     .await;
     Ok(())

--- a/crate/cli/src/actions/findex_server/tests/findex/basic.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/basic.rs
@@ -1,11 +1,8 @@
 use std::path::PathBuf;
 
 use cosmian_findex::{gen_seed, test_single_write_and_read, test_wrong_guard};
-use cosmian_findex_client::RestClient;
 use cosmian_findex_structs::{CUSTOM_WORD_LENGTH, Value};
-use cosmian_kms_cli::reexport::{
-    cosmian_kms_client::KmsClient, test_kms_server::start_default_test_kms_server,
-};
+use cosmian_kms_cli::reexport::test_kms_server::start_default_test_kms_server;
 use cosmian_logger::log_init;
 use test_findex_server::{
     start_default_test_findex_server, start_default_test_findex_server_with_cert_auth,
@@ -38,10 +35,10 @@ pub(crate) async fn test_findex_no_auth() -> FindexCliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server().await;
     let ctx_kms = start_default_test_kms_server().await;
-    let kms_client = KmsClient::new_with_config(ctx_kms.owner_client_config.clone())?;
+
     let findex_parameters = FindexParameters::new(
         Uuid::new_v4(),
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         true,
         findex_number_of_threads(),
     )
@@ -61,7 +58,7 @@ pub(crate) async fn test_findex_no_auth() -> FindexCliResult<()> {
         &findex_parameters,
         &ctx.owner_client_conf,
         search_options,
-        kms_client,
+        ctx_kms.get_owner_client(),
     )
     .await?;
     Ok(())
@@ -72,10 +69,10 @@ pub(crate) async fn test_findex_local_encryption() -> FindexCliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server().await;
     let ctx_kms = start_default_test_kms_server().await;
-    let kms_client = KmsClient::new_with_config(ctx_kms.owner_client_config.clone())?;
+
     let findex_parameters = FindexParameters::new(
         Uuid::new_v4(),
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         false,
         findex_number_of_threads(),
     )
@@ -95,7 +92,7 @@ pub(crate) async fn test_findex_local_encryption() -> FindexCliResult<()> {
         &findex_parameters,
         &ctx.owner_client_conf,
         search_options,
-        kms_client,
+        ctx_kms.get_owner_client(),
     )
     .await?;
     Ok(())
@@ -105,10 +102,10 @@ async fn run_huge_dataset_test(use_remote_crypto: bool) -> FindexCliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server().await;
     let ctx_kms = start_default_test_kms_server().await;
-    let kms_client = KmsClient::new_with_config(ctx_kms.owner_client_config.clone())?;
+
     let findex_parameters = FindexParameters::new(
         Uuid::new_v4(),
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         use_remote_crypto,
         findex_number_of_threads(),
     )
@@ -135,7 +132,7 @@ async fn run_huge_dataset_test(use_remote_crypto: bool) -> FindexCliResult<()> {
         &findex_parameters,
         &ctx.owner_client_conf,
         search_options,
-        kms_client,
+        ctx_kms.get_owner_client(),
     )
     .await
 }
@@ -156,9 +153,7 @@ pub(crate) async fn test_findex_huge_dataset_local_crypto() -> FindexCliResult<(
 pub(crate) async fn test_findex_cert_auth() -> FindexCliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server_with_cert_auth().await;
-    let owner_rest_client = RestClient::new(ctx.owner_client_conf.clone())?;
     let ctx_kms = start_default_test_kms_server().await;
-    let kms_client = KmsClient::new_with_config(ctx_kms.owner_client_config.clone())?;
 
     let search_options = SearchOptions {
         dataset_path: SMALL_DATASET.into(),
@@ -170,12 +165,12 @@ pub(crate) async fn test_findex_cert_auth() -> FindexCliResult<()> {
         },
     };
 
-    let index_id = create_index_id(owner_rest_client).await?;
+    let index_id = create_index_id(ctx.get_owner_client()).await?;
     trace!("index_id: {index_id}");
 
     let findex_parameters = FindexParameters::new(
         index_id,
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         true,
         findex_number_of_threads(),
     )
@@ -185,7 +180,7 @@ pub(crate) async fn test_findex_cert_auth() -> FindexCliResult<()> {
         &findex_parameters,
         &ctx.owner_client_conf,
         search_options,
-        kms_client,
+        ctx_kms.get_owner_client(),
     )
     .await?;
 
@@ -196,12 +191,9 @@ pub(crate) async fn test_findex_cert_auth() -> FindexCliResult<()> {
 pub(crate) async fn test_findex_searching_with_bad_key() -> FindexCliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server().await;
-
-    let rest_client = RestClient::new(ctx.owner_client_conf.clone())?;
     let ctx_kms = start_default_test_kms_server().await;
-    let kms_client = KmsClient::new_with_config(ctx_kms.owner_client_config.clone())?;
 
-    let index_id = create_index_id(rest_client.clone()).await?;
+    let index_id = create_index_id(ctx.get_owner_client()).await?;
     trace!("index_id: {index_id}");
 
     // Search 2 entries in a small dataset. Expect 2 results.
@@ -216,7 +208,7 @@ pub(crate) async fn test_findex_searching_with_bad_key() -> FindexCliResult<()> 
     };
     let findex_parameters = FindexParameters::new(
         Uuid::new_v4(),
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         true,
         findex_number_of_threads(),
     )
@@ -227,7 +219,7 @@ pub(crate) async fn test_findex_searching_with_bad_key() -> FindexCliResult<()> 
         findex_parameters: findex_parameters.clone(),
         csv: PathBuf::from(&search_options.dataset_path),
     }
-    .insert(rest_client.clone(), kms_client.clone())
+    .insert(ctx.get_owner_client(), ctx_kms.get_owner_client())
     .await?;
 
     // But change the findex keys
@@ -235,14 +227,14 @@ pub(crate) async fn test_findex_searching_with_bad_key() -> FindexCliResult<()> 
     let search_results = SearchAction {
         findex_parameters: FindexParameters::new(
             Uuid::new_v4(),
-            kms_client.clone(),
+            ctx_kms.get_owner_client(),
             true,
             findex_number_of_threads(),
         )
         .await?,
         keyword: search_options.keywords.clone(),
     }
-    .run(rest_client, kms_client)
+    .run(ctx.get_owner_client(), ctx_kms.get_owner_client())
     .await?;
     assert!(search_results.is_empty());
     Ok(())

--- a/crate/cli/src/actions/findex_server/tests/findex/permissions.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/permissions.rs
@@ -1,10 +1,7 @@
 use std::{ops::Deref, path::PathBuf};
 
-use cosmian_findex_client::RestClient;
 use cosmian_findex_structs::{Permission, Value};
-use cosmian_kms_cli::reexport::{
-    cosmian_kms_client::KmsClient, test_kms_server::start_default_test_kms_server,
-};
+use cosmian_kms_cli::reexport::test_kms_server::start_default_test_kms_server;
 use cosmian_logger::log_init;
 use test_findex_server::start_default_test_findex_server_with_cert_auth;
 use tracing::{debug, trace};
@@ -32,8 +29,6 @@ use crate::{
 pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<()> {
     log_init(None);
     let ctx = start_default_test_findex_server_with_cert_auth().await;
-    let owner_rest_client = RestClient::new(ctx.owner_client_conf.clone())?;
-
     let search_options = SearchOptions {
         dataset_path: SMALL_DATASET.into(),
         keywords: vec!["Southborough".to_owned()],
@@ -44,17 +39,14 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<(
         },
     };
 
-    let index_id = create_index_id(owner_rest_client).await?;
+    let index_id = create_index_id(ctx.get_owner_client()).await?;
     trace!("index_id: {index_id}");
 
-    let owner_rest_client = RestClient::new(ctx.owner_client_conf.clone())?;
-    let user_rest_client = RestClient::new(ctx.user_client_conf.clone())?;
     let ctx_kms = start_default_test_kms_server().await;
-    let kms_client = KmsClient::new_with_config(ctx_kms.owner_client_config.clone())?;
 
     let findex_parameters = FindexParameters::new(
         index_id,
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         true,
         findex_number_of_threads(),
     )
@@ -65,12 +57,12 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<(
         findex_parameters: findex_parameters.clone(),
         csv: PathBuf::from(SMALL_DATASET),
     }
-    .insert(owner_rest_client.clone(), kms_client.clone())
+    .insert(ctx.get_owner_client(), ctx_kms.get_owner_client())
     .await?;
 
     // Set read permission to the client
     set_permission(
-        owner_rest_client.clone(),
+        ctx.get_owner_client(),
         "user.client@acme.com".to_owned(),
         index_id,
         Permission::Read,
@@ -82,7 +74,7 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<(
         findex_parameters: findex_parameters.clone(),
         keyword: search_options.keywords.clone(),
     }
-    .run(user_rest_client.clone(), kms_client.clone())
+    .run(ctx.get_user_client(), ctx_kms.get_owner_client())
     .await?;
     assert_eq!(
         search_options.expected_results,
@@ -94,21 +86,20 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<(
         findex_parameters: findex_parameters.clone(),
         csv: PathBuf::from(SMALL_DATASET),
     }
-    .insert(user_rest_client.clone(), kms_client.clone())
+    .insert(ctx.get_user_client(), ctx_kms.get_owner_client())
     .await
     .unwrap_err();
 
     // Set write permission
     set_permission(
-        owner_rest_client.clone(),
+        ctx.get_owner_client(),
         "user.client@acme.com".to_owned(),
         index_id,
         Permission::Write,
     )
     .await?;
 
-    let perm =
-        list_permissions(owner_rest_client.clone(), "user.client@acme.com".to_owned()).await?;
+    let perm = list_permissions(ctx.get_owner_client(), "user.client@acme.com".to_owned()).await?;
     debug!("User permission: {:?}", perm);
 
     // User can read...
@@ -116,7 +107,7 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<(
         findex_parameters: findex_parameters.clone(),
         keyword: search_options.keywords.clone(),
     }
-    .run(user_rest_client.clone(), kms_client.clone())
+    .run(ctx.get_user_client(), ctx_kms.get_owner_client())
     .await?;
     assert_eq!(
         search_options.expected_results,
@@ -128,12 +119,12 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<(
         findex_parameters: findex_parameters.clone(),
         csv: PathBuf::from(SMALL_DATASET),
     }
-    .insert(user_rest_client.clone(), kms_client.clone())
+    .insert(ctx.get_user_client(), ctx_kms.get_owner_client())
     .await?;
 
     // Try to escalade privileges from `read` to `admin`
     set_permission(
-        user_rest_client.clone(),
+        ctx.get_user_client(),
         "user.client@acme.com".to_owned(),
         index_id,
         Permission::Admin,
@@ -142,7 +133,7 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<(
     .unwrap_err();
 
     revoke_permission(
-        owner_rest_client,
+        ctx.get_owner_client(),
         "user.client@acme.com".to_owned(),
         index_id,
     )
@@ -152,7 +143,7 @@ pub(crate) async fn test_findex_set_and_revoke_permission() -> FindexCliResult<(
         findex_parameters: findex_parameters.clone(),
         keyword: search_options.keywords.clone(),
     }
-    .run(user_rest_client.clone(), kms_client.clone())
+    .run(ctx.get_user_client(), ctx_kms.get_owner_client())
     .await
     .unwrap_err();
 
@@ -165,10 +156,9 @@ pub(crate) async fn test_findex_no_permission() -> FindexCliResult<()> {
     let ctx = start_default_test_findex_server_with_cert_auth().await;
 
     let ctx_kms = start_default_test_kms_server().await;
-    let kms_client = KmsClient::new_with_config(ctx_kms.owner_client_config.clone())?;
     let findex_parameters = FindexParameters::new(
         Uuid::new_v4(),
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         true,
         findex_number_of_threads(),
     )
@@ -189,7 +179,7 @@ pub(crate) async fn test_findex_no_permission() -> FindexCliResult<()> {
             &findex_parameters,
             &ctx.user_client_conf,
             search_options,
-            kms_client
+            ctx_kms.get_owner_client(),
         )
         .await
         .is_err()

--- a/crate/cli/src/actions/findex_server/tests/findex/utils.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/utils.rs
@@ -72,8 +72,10 @@ pub(crate) async fn insert_search_delete(
 
 pub(crate) async fn create_encryption_layer<const WORD_LENGTH: usize>()
 -> FindexCliResult<KmsEncryptionLayer<WORD_LENGTH, FindexRestClient<WORD_LENGTH>>> {
-    let ctx = start_default_test_findex_server().await;
-    let ctx_kms = start_default_test_kms_server().await;
+    let (ctx_findex, ctx_kms) = tokio::join!(
+        start_default_test_findex_server(),
+        start_default_test_kms_server()
+    );
 
     let findex_parameters = FindexParameters::new(
         Uuid::new_v4(),
@@ -87,7 +89,10 @@ pub(crate) async fn create_encryption_layer<const WORD_LENGTH: usize>()
         ctx_kms.get_owner_client(),
         findex_parameters.hmac_key_id.unwrap(),
         findex_parameters.aes_xts_key_id.unwrap(),
-        FindexRestClient::<WORD_LENGTH>::new(ctx.get_owner_client(), findex_parameters.index_id),
+        FindexRestClient::<WORD_LENGTH>::new(
+            ctx_findex.get_owner_client(),
+            findex_parameters.index_id,
+        ),
     );
     Ok(encryption_layer)
 }

--- a/crate/cli/src/actions/findex_server/tests/findex/utils.rs
+++ b/crate/cli/src/actions/findex_server/tests/findex/utils.rs
@@ -74,23 +74,20 @@ pub(crate) async fn create_encryption_layer<const WORD_LENGTH: usize>()
 -> FindexCliResult<KmsEncryptionLayer<WORD_LENGTH, FindexRestClient<WORD_LENGTH>>> {
     let ctx = start_default_test_findex_server().await;
     let ctx_kms = start_default_test_kms_server().await;
-    let kms_client = KmsClient::new_with_config(ctx_kms.owner_client_config.clone())?;
+
     let findex_parameters = FindexParameters::new(
         Uuid::new_v4(),
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         true,
         findex_number_of_threads(),
     )
     .await?;
 
     let encryption_layer = KmsEncryptionLayer::<WORD_LENGTH, _>::new(
-        kms_client.clone(),
+        ctx_kms.get_owner_client(),
         findex_parameters.hmac_key_id.unwrap(),
         findex_parameters.aes_xts_key_id.unwrap(),
-        FindexRestClient::<WORD_LENGTH>::new(
-            RestClient::new(ctx.owner_client_conf.clone())?,
-            findex_parameters.index_id,
-        ),
+        FindexRestClient::<WORD_LENGTH>::new(ctx.get_owner_client(), findex_parameters.index_id),
     );
     Ok(encryption_layer)
 }

--- a/crate/findex_client/src/kms/memory_adt.rs
+++ b/crate/findex_client/src/kms/memory_adt.rs
@@ -152,7 +152,10 @@ mod tests {
     use std::sync::Arc;
 
     use cosmian_crypto_core::{CsRng, Sampling, reexport::rand_core::SeedableRng};
-    use cosmian_findex::{InMemory, gen_seed, test_single_write_and_read, test_wrong_guard};
+    use cosmian_findex::{
+        InMemory, gen_seed, test_guarded_write_concurrent, test_single_write_and_read,
+        test_wrong_guard,
+    };
     use cosmian_findex_structs::CUSTOM_WORD_LENGTH;
     use cosmian_kms_cli::reexport::{
         cosmian_kms_client::{
@@ -400,14 +403,13 @@ mod tests {
         Ok(())
     }
 
-    // #[ignore = "stack overflow"]
-    // #[tokio::test]
-    // async fn test_concurrent_read_write() -> ClientResult<()> {
-    //     log_init(None);
-    //     let ctx = start_default_test_kms_server().await;
-    //     let memory = create_test_layer(ctx.owner_client_config.clone()).await?;
-    //     test_guarded_write_concurrent::<CUSTOM_WORD_LENGTH, _>(&memory, gen_seed(), Some(100))
-    //         .await;
-    //     Ok(())
-    // }
+    #[tokio::test]
+    async fn test_concurrent_read_write() -> ClientResult<()> {
+        log_init(None);
+        let ctx = start_default_test_kms_server().await;
+        let memory = create_test_layer(ctx.owner_client_config.clone()).await?;
+        test_guarded_write_concurrent::<CUSTOM_WORD_LENGTH, _>(&memory, gen_seed(), Some(100))
+            .await;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Reenable this test `test_findex_concurrent_read_write`:
- Decrease the number of threads on CI to 20
- Skip on Windows
- Simplify clients instantiation (KmsClient and RestClient)

Closes #73 