### PR TITLE
ci: split cargo cargo_build.sh into multiple files

### DIFF
--- a/.github/scripts/build_packages.sh
+++ b/.github/scripts/build_packages.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -exo pipefail
+
+# export FEATURES="non-fips"
+
+if [ -z "$TARGET" ]; then
+  echo "Error: TARGET is not set. Examples of TARGET are x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin."
+  exit 1
+fi
+
+if [ -n "$FEATURES" ]; then
+  FEATURES="--features $FEATURES"
+fi
+
+if [ -z "$FEATURES" ]; then
+  echo "Info: FEATURES is not set."
+  unset FEATURES
+fi
+
+if [ -z "$OPENSSL_DIR" ]; then
+  echo "Error: OPENSSL_DIR is not set. Example OPENSSL_DIR=/usr/local/openssl"
+  exit 1
+fi
+
+ROOT_FOLDER=$(pwd)
+
+if [ "$DEBUG_OR_RELEASE" = "release" ]; then
+  # First build the Debian and RPM packages. It must come at first since
+  # after this step `cosmian_findex_server` is built with custom features flags (non-fips for example).
+  rm -rf target/"$TARGET"/debian
+  rm -rf target/"$TARGET"/generate-rpm
+  if [ -f /etc/redhat-release ]; then
+    cd crate/server && cargo build --features non-fips --release --target "$TARGET" && cd -
+    cargo install --version 0.16.0 cargo-generate-rpm --force
+    cd "$ROOT_FOLDER"
+    cargo generate-rpm --target "$TARGET" -p crate/server --metadata-overwrite=pkg/rpm/scriptlets.toml
+  elif [ -f /etc/debian_version ]; then
+    cargo install --version 2.4.0 cargo-deb --force
+    if [ -n "$FEATURES" ]; then
+      cargo deb --target "$TARGET" -p cosmian_findex_server
+    else
+      cargo deb --target "$TARGET" -p cosmian_findex_server --variant fips
+    fi
+  fi
+fi

--- a/.github/scripts/cargo_build.ps1
+++ b/.github/scripts/cargo_build.ps1
@@ -20,11 +20,11 @@ function BuildProject {
     $env:FINDEX_TEST_DB = "sqlite-findex"
     if ($BuildType -eq "release") {
         cargo build --features "non-fips" -p cosmian_findex_server -p cosmian_findex_cli --release --target x86_64-pc-windows-msvc
-        cargo  test --features "non-fips" -p cosmian_findex_server -p cosmian_findex_cli --target x86_64-pc-windows-msvc -- --nocapture --skip kms --skip hsm --skip redis
+        cargo  test --features "non-fips" -p cosmian_findex_server -p cosmian_findex_cli --target x86_64-pc-windows-msvc -- --nocapture
     }
     else {
         cargo build --features "non-fips" -p cosmian_findex_server -p cosmian_findex_cli --target x86_64-pc-windows-msvc
-        cargo  test --features "non-fips" -p cosmian_findex_server -p cosmian_findex_cli --target x86_64-pc-windows-msvc -- --nocapture --skip kms --skip hsm --skip redis
+        cargo  test --features "non-fips" -p cosmian_findex_server -p cosmian_findex_cli --target x86_64-pc-windows-msvc -- --nocapture
     }
 
     # Check dynamic links

--- a/.github/scripts/cargo_build.sh
+++ b/.github/scripts/cargo_build.sh
@@ -1,31 +1,11 @@
 #!/bin/bash
 
-set -ex
+set -exo pipefail
 
-# --- Declare the following variables for tests
-# export TARGET=aarch64-apple-darwin
-# export DEBUG_OR_RELEASE=debug
-# export SKIP_SERVICES_TESTS="--skip test_findex --skip test_all_authentications --skip test_server_auth_matrix --skip test_datasets"
-
-ROOT_FOLDER=$(pwd)
-
-if [ "$DEBUG_OR_RELEASE" = "release" ]; then
-  # First build the Debian and RPM packages.
-  rm -rf target/"$TARGET"/debian
-  rm -rf target/"$TARGET"/generate-rpm
-  if [ -f /etc/redhat-release ]; then
-    cd crate/server && cargo build --target "$TARGET" --release && cd -
-    cargo install --version 0.16.0 cargo-generate-rpm --force
-    cd "$ROOT_FOLDER"
-    cargo generate-rpm --target "$TARGET" -p crate/server --metadata-overwrite=pkg/rpm/scriptlets.toml
-  elif [ -f /etc/debian_version ]; then
-    cargo install --version 2.4.0 cargo-deb --force
-    cargo deb --target "$TARGET" -p cosmian_findex_server
-  fi
-fi
+# export FEATURES="non-fips"
 
 if [ -z "$TARGET" ]; then
-  echo "Error: TARGET is not set."
+  echo "Error: TARGET is not set. Examples of TARGET are x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin."
   exit 1
 fi
 
@@ -33,23 +13,43 @@ if [ "$DEBUG_OR_RELEASE" = "release" ]; then
   RELEASE="--release"
 fi
 
-if [ -z "$SKIP_SERVICES_TESTS" ]; then
-  echo "Info: SKIP_SERVICES_TESTS is not set."
-  unset SKIP_SERVICES_TESTS
+if [ -n "$FEATURES" ]; then
+  FEATURES="--features $FEATURES"
+fi
+
+if [ -z "$FEATURES" ]; then
+  echo "Info: FEATURES is not set."
+  unset FEATURES
+fi
+
+if [ -z "$OPENSSL_DIR" ]; then
+  echo "Error: OPENSSL_DIR is not set. Example OPENSSL_DIR=/usr/local/openssl"
+  exit 1
 fi
 
 rustup target add "$TARGET"
 
 # shellcheck disable=SC2086
-cargo build --target $TARGET $RELEASE
+cargo build -p cosmian_findex_server -p cosmian_findex_cli --target $TARGET $RELEASE $FEATURES
 
-export RUST_LOG="fatal,cosmian_findex_cli=error,cosmian_findex_client=debug,cosmian_findex_server=debug"
+COSMIAN_FINDEX_SERVER_EXE="target/$TARGET/$DEBUG_OR_RELEASE/cosmian_findex_server"
 
-declare -a DATABASES=('redis-findex' 'sqlite-findex')
-for FINDEX_TEST_DB in "${DATABASES[@]}"; do
-  echo "Database FINDEX: $FINDEX_TEST_DB"
+# Test binary functionality
+."/$COSMIAN_FINDEX_SERVER_EXE" --help
 
-  export FINDEX_TEST_DB="$FINDEX_TEST_DB"
-  # shellcheck disable=SC2086
-  cargo test --workspace --lib --target $TARGET $RELEASE $FEATURES -- --nocapture $SKIP_SERVICES_TESTS
-done
+# Check for dynamic OpenSSL linkage
+if [ "$(uname)" = "Linux" ]; then
+  LDD_OUTPUT_SERVER=$(ldd "$COSMIAN_FINDEX_SERVER_EXE")
+  echo "Server LDD output: $LDD_OUTPUT_SERVER"
+  if echo "$LDD_OUTPUT_SERVER" | grep -qi ssl; then
+    echo "Error: Dynamic OpenSSL linkage detected on Linux (ldd | grep ssl)."
+    exit 1
+  fi
+else
+  OTOOL_OUTPUT_SERVER=$(otool -L "$COSMIAN_FINDEX_SERVER_EXE")
+  echo "Server otool output: $OTOOL_OUTPUT_SERVER"
+  if echo "$OTOOL_OUTPUT_SERVER" | grep -qi ssl; then
+    echo "Error: Dynamic OpenSSL linkage detected on macOS (otool -L | grep openssl)."
+    exit 1
+  fi
+fi

--- a/.github/scripts/cargo_test.sh
+++ b/.github/scripts/cargo_test.sh
@@ -33,7 +33,7 @@ export RUST_LOG="cosmian_findex_cli=error,cosmian_findex_server=error,cosmian_fi
 cargo test --workspace --bins --target $TARGET $RELEASE $FEATURES
 
 # shellcheck disable=SC2086
-cargo bench --target $TARGET $FEATURES --no-run
+# cargo bench --target $TARGET $FEATURES --no-run
 
 echo "SQLite is running on filesystem"
 # shellcheck disable=SC2086
@@ -46,3 +46,5 @@ if nc -z "$REDIS_HOST" "$REDIS_PORT"; then
 else
   echo "Redis is not running at $REDIS_HOST:$REDIS_PORT"
 fi
+
+echo "All Findex server tests completed successfully"

--- a/.github/scripts/cargo_test.sh
+++ b/.github/scripts/cargo_test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -exo pipefail
+
+# export FEATURES="non-fips"
+
+if [ -z "$TARGET" ]; then
+  echo "Error: TARGET is not set. Examples of TARGET are x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin."
+  exit 1
+fi
+
+if [ "$DEBUG_OR_RELEASE" = "release" ]; then
+  RELEASE="--release"
+fi
+
+if [ -n "$FEATURES" ]; then
+  FEATURES="--features $FEATURES"
+fi
+
+if [ -z "$FEATURES" ]; then
+  echo "Info: FEATURES is not set."
+  unset FEATURES
+fi
+
+if [ -z "$OPENSSL_DIR" ]; then
+  echo "Error: OPENSSL_DIR is not set. Example OPENSSL_DIR=/usr/local/openssl"
+  exit 1
+fi
+
+export RUST_LOG="cosmian_findex_cli=error,cosmian_findex_server=error,cosmian_findex_client=debug"
+
+# shellcheck disable=SC2086
+cargo test --workspace --bins --target $TARGET $RELEASE $FEATURES
+
+# shellcheck disable=SC2086
+cargo bench --target $TARGET $FEATURES --no-run
+
+echo "SQLite is running on filesystem"
+# shellcheck disable=SC2086
+FINDEX_TEST_DB="sqlite-findex" cargo test --workspace --lib --target $TARGET $RELEASE $FEATURES -- --nocapture
+
+if nc -z "$REDIS_HOST" "$REDIS_PORT"; then
+  echo "Redis is running at $REDIS_HOST:$REDIS_PORT"
+  # shellcheck disable=SC2086
+  FINDEX_TEST_DB="redis-findex" cargo test --workspace --lib --target $TARGET $RELEASE $FEATURES -- --nocapture
+else
+  echo "Redis is not running at $REDIS_HOST:$REDIS_PORT"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 cosmian-findex-server/
 .venv/
 **/sqlite-test*
+**/sqlite-data*
 crate/server/*.db*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,11 +132,10 @@ repos:
       - id: docker-compose-up
       - id: cargo-build
       - id: cargo-test
-        args: [--, --skip, test_wrap_auth, --skip, google_cse, --skip, hsm]
       - id: cargo-build-all
       - id: cargo-test
         alias: cargo-test-all
-        args: [--all-features, --, --skip, test_wrap_auth, --skip, google_cse, --skip, hsm]
+        args: [--all-features]
       - id: clippy-autofix-unreachable-pub
       - id: clippy-autofix-all-targets-all-features
       - id: clippy-autofix-all-targets

--- a/crate/test_findex_server/src/test_server.rs
+++ b/crate/test_findex_server/src/test_server.rs
@@ -60,11 +60,14 @@ fn sqlite_db_config(sqlite_url_var_env: &str) -> DBConfig {
 }
 
 pub fn get_db_config() -> DBConfig {
-    env::var_os("FINDEX_TEST_DB").map_or_else(redis_db_config, |v| match v.to_str().unwrap_or("") {
-        "redis-findex" => redis_db_config(),
-        "sqlite-findex" => sqlite_db_config("FINDEX_SQLITE_URL"),
-        _ => redis_db_config(),
-    })
+    env::var_os("FINDEX_TEST_DB").map_or_else(
+        || sqlite_db_config("FINDEX_SQLITE_URL"),
+        |v| match v.to_str().unwrap_or("") {
+            "redis-findex" => redis_db_config(),
+            "sqlite-findex" => sqlite_db_config("FINDEX_SQLITE_URL"),
+            _ => sqlite_db_config("FINDEX_SQLITE_URL"),
+        },
+    )
 }
 
 /// Start a test Findex server in a thread with the default options:


### PR DESCRIPTION
- Make cargo test working by default
- Remove --skip args